### PR TITLE
Hotfix: Turn locale decimal format into dot-notation (github #105)

### DIFF
--- a/components/core/parcel-template.php
+++ b/components/core/parcel-template.php
@@ -372,10 +372,10 @@ class WCSC_Parceltemplate_Posttype
 		        'package' => $_POST[ 'shipcloud_carrier_package' ],
         );
 
-		$width   = $_POST[ 'width' ];
-		$height  = $_POST[ 'height' ];
-		$length  = $_POST[ 'length' ];
-		$weight  = $_POST[ 'weight' ];
+		$width  = wc_format_decimal( $_POST['width'] );
+		$height = wc_format_decimal( $_POST['height'] );
+		$length = wc_format_decimal( $_POST['length'] );
+		$weight = wc_format_decimal( $_POST['weight'] );
 
 		$post_title = wcsc_get_carrier_display_name( $carrier ) . ' - ' . $width . ' x ' . $height . ' x ' . $length . ' ' . __( 'cm', 'shipcloud-for-woocommerce' ) . ' ' . $weight . __( 'kg', 'shipcloud-for-woocommerce' );
 

--- a/components/woo/order-bulk.php
+++ b/components/woo/order-bulk.php
@@ -364,10 +364,10 @@ class WC_Shipcloud_Order_Bulk {
 				'parcel_id'           => $shipment->getId(),
 				'parcel_title'        => $parcel_title,
 				'carrier'             => $request['shipcloud_carrier'],
-				'width'               => $request['parcel_width'],
-				'height'              => $request['parcel_height'],
-				'length'              => $request['parcel_length'],
-				'weight'              => $request['parcel_weight'],
+				'width'               => wc_format_decimal( $request['parcel_width'] ),
+				'height'              => wc_format_decimal( $request['parcel_height'] ),
+				'length'              => wc_format_decimal( $request['parcel_length'] ),
+				'weight'              => wc_format_decimal( $request['parcel_weight'] ),
 				'date_created'        => time(),
 			);
 

--- a/components/woo/order.php
+++ b/components/woo/order.php
@@ -223,6 +223,28 @@ class WC_Shipcloud_Order
 	}
 
 	/**
+     * Sanitize package data.
+     *
+     * User enter package data that can:
+     *
+     * - Have local decimal separator.
+     *
+     * @since 1.4.0
+     *
+	 * @param array $package_data
+	 *
+	 * @return array
+	 */
+	protected function sanitize_package( $package_data ) {
+		$package_data['width']  = wc_format_decimal( $package_data['width'] );
+		$package_data['height'] = wc_format_decimal( $package_data['height'] );
+		$package_data['length'] = wc_format_decimal( $package_data['length'] );
+		$package_data['weight'] = wc_format_decimal( $package_data['weight'] );
+
+		return $package_data;
+	}
+
+	/**
 	 * Product metabox
 	 *
 	 * @since 1.0.0
@@ -954,6 +976,10 @@ class WC_Shipcloud_Order
 
 		$data['notification_mail'] = $this->get_notification_email();
 		$data                      = $this->sanitize_shop_owner_data( $data );
+
+		if ( array_key_exists( 'package', $data ) ) {
+			$data['package'] = $this->sanitize_package( $data['package'] );
+		}
 
 		try {
 			$shipment = _wcsc_api()->shipment()->create( $data );

--- a/components/woo/order.php
+++ b/components/woo/order.php
@@ -883,10 +883,10 @@ class WC_Shipcloud_Order
 		$shipcloud_api = new Woocommerce_Shipcloud_API( $options[ 'api_key' ] );
 
 		$package = array(
-			'width'  => $_POST[ 'width' ],
-			'height' => $_POST[ 'height' ],
-			'length' => $_POST[ 'length' ],
-			'weight' => str_replace( ',', '.', $_POST[ 'weight' ] ),
+			'width'  => wc_format_decimal( $_POST[ 'width' ] ),
+			'height' => wc_format_decimal( $_POST[ 'height' ] ),
+			'length' => wc_format_decimal( $_POST[ 'length' ] ),
+			'weight' => wc_format_decimal( $_POST[ 'weight' ] ),
 		);
 
 		$price = $shipcloud_api->get_price( $_POST[ 'carrier' ], $_POST['sender'], $_POST['recipient'], $package );

--- a/components/woo/shipping-classes.php
+++ b/components/woo/shipping-classes.php
@@ -174,22 +174,22 @@ class WC_Shipcloud_Shippig_Classes
     {
 	    if ( isset( $data['width'] ) )
 	    {
-            $parcel_width = wc_clean( $data['width'] );
+            $parcel_width = wc_format_decimal( wc_clean( $data['width'] ) );
 	    }
 
 	    if ( isset( $data['height'] ) )
 	    {
-            $parcel_height = wc_clean( $data['height'] );
+            $parcel_height = wc_format_decimal( wc_clean( $data['height'] ) );
 	    }
 
 	    if ( isset( $data['length'] ) )
 	    {
-            $parcel_length = wc_clean( $data['length'] );
+            $parcel_length = wc_format_decimal( wc_clean( $data['length'] ) );
 	    }
 
 	    if ( isset( $data['weight'] ) )
 	    {
-            $parcel_weight = wc_clean( $data['weight'] );
+            $parcel_weight = wc_format_decimal( wc_clean( $data['weight'] ) );
 	    }
 
 	    if( is_array( $term_id ) )

--- a/components/woo/shipping-method.php
+++ b/components/woo/shipping-method.php
@@ -1240,10 +1240,10 @@ class WC_Shipcloud_Shipping extends WC_Shipping_Method
 		$this->init_shipcloud_api();
 
 		$package = array(
-			'width'  => $parcel[ 'width' ],
-			'height' => $parcel[ 'height' ],
-			'length' => $parcel[ 'length' ],
-			'weight' => str_replace( ',', '.', $parcel[ 'weight' ] ),
+			'width'  => wc_format_decimal( $parcel[ 'width' ] ),
+			'height' => wc_format_decimal( $parcel[ 'height' ] ),
+			'length' => wc_format_decimal( $parcel[ 'length' ] ),
+			'weight' => wc_format_decimal( $parcel[ 'weight' ] ),
 		);
 
 		$price = $this->shipcloud_api->get_price( $carrier_name, $this->sender, $this->recipient, $package );
@@ -1276,21 +1276,20 @@ class WC_Shipcloud_Shipping extends WC_Shipping_Method
 
 		foreach ( $parcels AS $key => $parcel )
 		{
-			if ( is_array( $parcel ) && array_key_exists( 'width', $parcel ) && array_key_exists( 'height', $parcel ) && array_key_exists( 'length', $parcel ) )
-			{
-				$parcel_volume = absint( $parcel[ 'width' ] ) * absint( $parcel[ 'height' ] ) * absint( $parcel[ 'length' ] );
-				$parcel_weight = floatval( $parcel[ 'weight' ] );;
+			if ( is_array( $parcel ) && array_key_exists( 'width', $parcel ) && array_key_exists( 'height', $parcel ) && array_key_exists( 'length', $parcel ) ) {
+				$parcel_volume = absint( wc_format_decimal( $parcel['width'] ) )
+								 * absint( wc_format_decimal( $parcel['height'] ) )
+								 * absint( wc_format_decimal( $parcel['length'] ) );
+				$parcel_weight = floatval( wc_format_decimal( $parcel['weight'] ) );
 
-				if( array_key_exists( 'quantity', $parcel ) )
-				{
-					$parcel_volume = absint( $parcel[ 'quantity' ] ) * $parcel_volume;
-					$parcel_weight = absint( $parcel[ 'quantity' ] ) * $parcel_weight;
+				if ( array_key_exists( 'quantity', $parcel ) ) {
+					$parcel_volume = absint( $parcel['quantity'] ) * $parcel_volume;
+					$parcel_weight = absint( $parcel['quantity'] ) * $parcel_weight;
 				}
 
 				$total_volume += $parcel_volume;
 				$total_weight += $parcel_weight;
-			}
-			else
+			} else
 			{
 				return new WP_Error( 'wcsc-calculate-virtual-parcel-missing-parcel', __( 'Parcel dimensions are missing', 'shipcloud-for-woocommerce' ) );
 			}


### PR DESCRIPTION
Decimal separator for units like cm, kg etc differ per locale.
This leads to problems as the API only allows a dot for decimals.
A WooCommerce function has been used to sanitize the data before submitting it to the API.

- Used `wc_format_decimal` to turn each decimal separator into "." (dot).
- Minor code format enhancements (as WP likes tabs more than spaces).