### PR TITLE
Bulk: Bring in parcel template autofill (github #66)

### DIFF
--- a/components/block/order-labels-bulk.php
+++ b/components/block/order-labels-bulk.php
@@ -21,7 +21,32 @@
             <fieldset class="inline-edit-col-right">
                 <div class="inline-edit-col">
                     <div class="inline-edit-group wp-clearfix" id="shipcloud_bulk">
-                        <?php echo $this->label_form->render() ?>
+                        <div class="alignleft">
+							<?php echo $this->label_form->render() ?>
+                        </div>
+
+                        <label class="alignleft">
+                            <span class="title">
+                                <?php esc_html_e( 'Template', 'shipcloud-for-woocommerce' ) ?>
+                            </span>
+							<?php if ( count( $this->get_parcel_templates() ) > 0 ) : ?>
+                                <select name="parcel_list">
+                                    <option value="none"><?php _e( '[ Select a parcel ]', 'shipcloud-for-woocommerce' ); ?></option>
+
+									<?php foreach ( $this->get_parcel_templates() AS $parcel_template ): ?>
+                                        <option value="<?php echo $parcel_template['value']; ?>"
+											<?php foreach ( $parcel_template['data'] as $field => $value ): ?>
+                                                data-<?php echo $field ?>="<?php esc_attr_e( $value ) ?>"
+											<?php endforeach; ?>
+                                        >
+											<?php echo $parcel_template['option']; ?>
+                                        </option>
+									<?php endforeach; ?>
+                                </select>
+							<?php else: ?>
+                                <p><?php echo sprintf( __( 'Please <a href="%s">add parcel templates</a> if you want to use.', 'shipcloud-for-woocommerce' ), admin_url( 'edit.php?post_type=sc_parcel_template' ) ); ?></p>
+							<?php endif; ?>
+                        </label>
                     </div>
                 </div>
             </fieldset>
@@ -47,6 +72,7 @@
 <script type="application/javascript">
     jQuery(function ($) {
         $('#shipcloud_bulk').find('#shipcloud_csp_wrapper').shipcloudMultiSelect(wcsc_carrier);
+        $('select[name="parcel_list"]').shipcloudFiller('table.parcel-form-table');
     });
 </script>
 

--- a/components/block/order-labels-bulk.php
+++ b/components/block/order-labels-bulk.php
@@ -21,12 +21,7 @@
             <fieldset class="inline-edit-col-right">
                 <div class="inline-edit-col">
                     <div class="inline-edit-group wp-clearfix" id="shipcloud_bulk">
-                        <div class="alignleft">
-							<?php echo $this->label_form->render() ?>
-                        </div>
-
-                        <label class="alignleft">
-                            <span class="title">
+                            <span style="display: inline-block; width: 9em; line-height: 1.3em; font-size: 14px; padding: 8px 0 42px 10px">
                                 <?php esc_html_e( 'Template', 'shipcloud-for-woocommerce' ) ?>
                             </span>
 							<?php if ( count( $this->get_parcel_templates() ) > 0 ) : ?>
@@ -46,7 +41,8 @@
 							<?php else: ?>
                                 <p><?php echo sprintf( __( 'Please <a href="%s">add parcel templates</a> if you want to use.', 'shipcloud-for-woocommerce' ), admin_url( 'edit.php?post_type=sc_parcel_template' ) ); ?></p>
 							<?php endif; ?>
-                        </label>
+
+							<?php echo $this->label_form->render() ?>
                     </div>
                 </div>
             </fieldset>

--- a/components/woo/order-bulk.php
+++ b/components/woo/order-bulk.php
@@ -116,7 +116,7 @@ class WC_Shipcloud_Order_Bulk {
 			WCSC_COMPONENTFOLDER . '/block/order-labels-bulk.php',
 			WC_Shipcloud_Order::create_order(null),
 			_wcsc_api()->carriers()->get(),
-			new Woocommerce_Shipcloud_API()
+			wcsc_api()
 		);
 
 		$block->dispatch();

--- a/includes/shipcloud/shipcloud.php
+++ b/includes/shipcloud/shipcloud.php
@@ -514,7 +514,9 @@ class Woocommerce_Shipcloud_API
 	 *
 	 * @param string $carrier_name
 	 *
-	 * @return string
+	 * @internal 2.0.0 Use proper Carrier instance as argument.
+	 *
+	 * @return string|array
 	 * @since 1.0.0
 	 */
 	public function get_carrier_display_name_short( $carrier_name ) {


### PR DESCRIPTION
See comment https://github.com/awsmug/shipcloud-for-woocommerce/issues/66#issuecomment-317337977

Parcel template selection was missing for bulk action due to the new form.
This merge will bring it back.