### PR TITLE
Add input field for phone to from and to address #81

### DIFF
--- a/components/woo/order.php
+++ b/components/woo/order.php
@@ -381,6 +381,11 @@ class WC_Shipcloud_Order
                             <?php _e( 'Country', 'shipcloud-for-woocommerce' ); ?>
                         </label>
                     </p>
+
+                    <p class="fullsize">
+                        <input type="text" name="sender_address[phone]" value="<?php echo $sender[ 'phone' ]; ?>" disabled>
+                        <label for="sender_address[phone]"><?php _e( 'Phone', 'shipcloud-for-woocommerce' ); ?></label>
+                    </p>
                 </div>
 			</div>
 

--- a/components/woo/order.php
+++ b/components/woo/order.php
@@ -1259,6 +1259,7 @@ class WC_Shipcloud_Order
 				$prefix . 'city'       => $options['sender_city'],
 				$prefix . 'state'      => $options['sender_state'],
 				$prefix . 'country'    => $options['sender_country'],
+				$prefix . 'phone'      => $options['sender_phone'],
 			);
 		}
 

--- a/components/woo/shipping-method.php
+++ b/components/woo/shipping-method.php
@@ -470,6 +470,12 @@ class WC_Shipcloud_Shipping extends WC_Shipping_Method
 				'options'     => $woocommerce->countries->countries,
 				'default'     => $default_country
 			),
+			'sender_phone'                    => array(
+				'title'       => __( 'Phone', 'shipcloud-for-woocommerce' ),
+				'type'        => 'text',
+				'description' => __( 'Enter standard phone number for sender.', 'shipcloud-for-woocommerce' ),
+				'desc_tip'    => true,
+			),
 			'recipient_information'              => array(
 				'title'       => __( 'Recipient information', 'shipcloud-for-woocommerce' ),
 				'type'        => 'title',
@@ -944,6 +950,7 @@ class WC_Shipcloud_Shipping extends WC_Shipping_Method
 			'city'      => $this->get_option( 'sender_city' ),
 			'state'     => $this->get_option( 'sender_state' ),
 			'country'   => $this->get_option( 'sender_country' ),
+			'phone'   => $this->get_option( 'sender_phone' ),
 		);
 	}
 

--- a/includes/js/shipcloud-label-form.js
+++ b/includes/js/shipcloud-label-form.js
@@ -36,7 +36,8 @@ shipcloud.LabelForm = function (wrapperSelector) {
             'zip_code'  : $('input[name="sender_address[zip_code]"]', self.$wrapper).val(),
             'city'      : $('input[name="sender_address[city]"]', self.$wrapper).val(),
             'state'     : $('input[name="sender_address[state]"]', self.$wrapper).val(),
-            'country'   : $('select[name="sender_address[country]"]', self.$wrapper).val()
+            'country'   : $('select[name="sender_address[country]"]', self.$wrapper).val(),
+            'phone'     : $('input[name="sender_address[phone]"]', self.$wrapper).val()
         };
     };
 


### PR DESCRIPTION
As of https://github.com/awsmug/shipcloud-for-woocommerce/issues/81#issuecomment-319443853 the sender should also have a phone field.