### PR TITLE
Hotfix: Either show error messages or prepend the HTML

### DIFF
--- a/components/woo/order.php
+++ b/components/woo/order.php
@@ -1344,7 +1344,7 @@ class WC_Shipcloud_Order
 			return (string) $phone;
 		}
 
-		return (string) $order->get_billing_phone();
+		return (string) $order->billing_phone;
 	}
 
 	/**

--- a/includes/js/admin.js
+++ b/includes/js/admin.js
@@ -117,26 +117,18 @@ jQuery( function( $ ) {
 		var button = $( '#shipcloud_create_shipment_return' );
 		button.addClass( 'button-loading' );
 
-		$.post( ajaxurl, data, function( response )
-		{
-			var result = JSON.parse( response );
+		$.post( ajaxurl, data, function (response) {
+            button.removeClass('button-loading');
 
-			if( result.status == 'ERROR' )
-			{
-				print_errors( result.errors );
-			}
+            if (!response.success) {
+                print_errors(_(response.data).pluck('message'));
+                return;
+            }
 
-			if( result.status == 'OK' )
-			{
-				$( '.shipment-labels' ).prepend( result.html );
-				shipcloud_create_label_buttons();
-				shipcloud_delete_shipment_buttons();
-
-				// $( '#shipcloud_create_label').fadeIn();
-			}
-
-			button.removeClass( 'button-loading' );
-		});
+            $('.shipment-labels').prepend(response.data.html);
+            shipcloud_create_label_buttons();
+            shipcloud_delete_shipment_buttons();
+        });
 	});
 
 	$( '#shipcloud_create_shipment_label' ).click( function(){

--- a/includes/js/admin.js
+++ b/includes/js/admin.js
@@ -95,23 +95,17 @@ jQuery( function( $ ) {
 
 		$.post( ajaxurl, data, function( response )
 		{
-			var result = JSON.parse( response );
-
-			if( result.status == 'ERROR' )
-			{
-				print_errors( result.errors );
-			}
-
-			if( result.status == 'OK' )
-			{
-				$( '.shipment-labels' ).prepend( result.html );
-				shipcloud_create_label_buttons();
-				shipcloud_delete_shipment_buttons();
-
-				// $( '#shipcloud_create_label').fadeIn();
-			}
-
 			button.removeClass( 'button-loading' );
+
+			if( ! response.success )
+			{
+				print_errors( _( response.data ).pluck('message') );
+				return;
+			}
+
+			$( '.shipment-labels' ).prepend( response.data.html );
+			shipcloud_create_label_buttons();
+			shipcloud_delete_shipment_buttons();
 		});
 	});
 


### PR DESCRIPTION
Since the AJAX call returns the proper
"Content-Type: application/json" in the header,
jQuery parses the received JSON.
This used to be interpreted again
and therefor breaks the script.
Parsing the JSON twice has been removed.

- fixes #133