### PR TITLE
Hotfix: Only print out bulk action template when in order list

### DIFF
--- a/components/woo/order-bulk.php
+++ b/components/woo/order-bulk.php
@@ -110,11 +110,20 @@ class WC_Shipcloud_Order_Bulk {
 	 * @since   1.2.1
 	 */
 	public function admin_print_footer_scripts() {
+
+		if (
+			false === get_current_screen() instanceof \WP_Screen
+			|| 'edit-shop_order' !== get_current_screen()->id
+		) {
+			// Not the context for bulk action so we won't print the bulk template.
+			return;
+		}
+
 		require_once WCSC_FOLDER . '/includes/shipcloud/block-order-labels-bulk.php';
 
 		$block = new WooCommerce_Shipcloud_Block_Order_Labels_Bulk(
 			WCSC_COMPONENTFOLDER . '/block/order-labels-bulk.php',
-			WC_Shipcloud_Order::create_order(null),
+			WC_Shipcloud_Order::create_order( null ),
 			_wcsc_carriers_get(),
 			wcsc_api()
 		);


### PR DESCRIPTION
The bulk action template were printed
on multiple occasions in the backend.
This lead to a JS error as the browser tries to interpret
the code of the template.
Printing the bulk action template
has been limited to the order list view.

- see support issues