### PR TITLE
fix data output and sanitation

### DIFF
--- a/components/woo/order.php
+++ b/components/woo/order.php
@@ -783,15 +783,15 @@ class WC_Shipcloud_Order
 						<div class="sender_street"><?php echo $data[ 'sender_street' ]; ?> <?php echo $data[ 'sender_street_no' ]?: $data[ 'sender_street_nr' ]; ?></div>
 						<div class="sender_city"><?php echo $data[ 'sender_zip_code' ]; ?> <?php echo $data[ 'sender_city' ]; ?></div>
 						<div class="sender_state"><?php echo $data[ 'sender_state' ]; ?></div>
-						<div class="sender_country"><?php echo $data[ 'country' ]; ?></div>
+						<div class="sender_country"><?php echo (isset($data['country'])) ? $data[ 'country' ] : ''; ?></div>
 					</div>
 
 					<div class="label-shipment-recipient address">
-						<div class="recipient_company"><?php echo $data[ 'recipient_company' ]; ?></div>
+						<div class="recipient_company"><?php echo (isset($data['recipient_company'])) ? $data[ 'recipient_company' ] : ''; ?></div>
 						<div class="recipient_name"><?php echo $data[ 'recipient_first_name' ]; ?> <?php echo $data[ 'recipient_last_name' ]; ?></div>
 						<div class="recipient_street"><?php echo $data[ 'recipient_street' ]; ?> <?php echo $data[ 'recipient_street_no' ]?: $data[ 'recipient_street_nr' ]; ?></div>
 						<div class="recipient_city"><?php echo $data[ 'recipient_zip_code' ]; ?> <?php echo $data[ 'recipient_city' ]; ?></div>
-						<div class="recipient_state"><?php echo $data[ 'recipient_state' ]; ?></div>
+						<div class="recipient_state"><?php echo (isset($data['recipient_state'])) ? $data[ 'recipient_state' ] : ''; ?></div>
 						<div class="recipient_country"><?php echo $data[ 'recipient_country' ]; ?></div>
 					</div>
 
@@ -821,10 +821,16 @@ class WC_Shipcloud_Order
 					<div class="label-shipment-status">
 						<table>
 							<tbody>
+							<?
+								if ( (isset($data['recipient_company'])) ) {
+							?>
 							<tr>
 								<th><?php _e( 'Shipment description', 'shipcloud-for-woocommerce' ); ?>:</th>
 								<td><?php echo $data[ 'description' ]; ?></td>
 							</tr>
+							<?
+								}
+							?>
 							<tr>
 								<th><?php _e( 'Shipment id:', 'shipcloud-for-woocommerce' ); ?></th>
 								<td><?php echo $display_id; ?></td>

--- a/components/woo/order.php
+++ b/components/woo/order.php
@@ -1566,7 +1566,7 @@ class WC_Shipcloud_Order
 						. $data->height . ';'
 						. $data->length . ';'
 						. $data->weight . ';'
-						. $data->carrier . ';',
+						. $data->carrier['carrier'] . ';',
 			'option' => $option,
 			'data'   => array(
 				'parcel_width'      => $data->width,

--- a/components/woo/order.php
+++ b/components/woo/order.php
@@ -1403,7 +1403,7 @@ class WC_Shipcloud_Order
 			$data[ $prefix . 'zip_code' ] = $data[ $prefix . 'postcode' ];
 		}
 
-		return array_filter( $data, array(__CLASS__, 'filterArrayPreserveEmptyString') );
+		return array_filter( $data, array($this, 'filterArrayPreserveEmptyString') );
 	}
 
 	/**

--- a/components/woo/order.php
+++ b/components/woo/order.php
@@ -763,7 +763,10 @@ class WC_Shipcloud_Order
 
 				$title = trim( $data[ 'sender_company' ] ) != '' ? $data[ 'sender_company' ] . ', ' . $data[ 'sender_first_name' ] . ' ' . $data[ 'sender_last_name' ] : $data[ 'sender_first_name' ] . ' ' . $data[ 'sender_last_name' ];
 				$title .= ' <span class="dashicons dashicons-arrow-right-alt"></span> ';
-				$title .= trim( $data[ 'recipient_company' ] ) != '' ? $data[ 'recipient_company' ] . ', ' . $data[ 'recipient_first_name' ] . ' ' . $data[ 'recipient_last_name' ] : $data[ 'recipient_first_name' ] . ' ' . $data[ 'recipient_last_name' ];
+				if ( isset($data['recipient_company']) ) {
+					$title .= $data[ 'recipient_company' ] . ', ';
+				}
+				$title .= $data[ 'recipient_first_name' ] . ' ' . $data[ 'recipient_last_name' ];
 				$title .= ' <span class="dashicons dashicons-screenoptions"></span> <small>' . trim($data[ 'parcel_title' ], ' -') . '</small>';
 
 				?>

--- a/components/woo/order.php
+++ b/components/woo/order.php
@@ -1434,9 +1434,9 @@ class WC_Shipcloud_Order
 			$order_id = $_POST['order_id'];
 		}
 
-		$factory = WC()->order_factory;
+		$factory = new WC_Order_Factory();
 
-		return $this->wc_order = $factory::get_order( $order_id );
+		return $this->wc_order = $factory->get_order( $order_id );
 	}
 
 	/**

--- a/components/woo/order.php
+++ b/components/woo/order.php
@@ -65,6 +65,10 @@ class WC_Shipcloud_Order
 		$this->init_hooks();
 	}
 
+	public function filterArrayPreserveEmptyString( $var ) {
+		return ($var !== NULL && $var !== FALSE);
+	}
+
 	/**
      * Backward compatibility to WC2
      *
@@ -347,7 +351,7 @@ class WC_Shipcloud_Order
 					</p>
 
 					<p class="twentyfive">
-						<input type="text" name="sender_address[street_nr]" value="<?php echo $sender[ 'street_nr' ]?: $sender[ 'street_no' ]; ?>" disabled>
+						<input type="text" name="sender_address[street_nr]" value="<?php echo isset($sender[ 'street_nr' ]) ? $sender[ 'street_nr' ] : $sender[ 'street_no' ]; ?>" disabled>
 						<label for="sender_address[street_nr]"><?php _e( 'Number', 'shipcloud-for-woocommerce' ); ?></label>
 					</p>
 
@@ -1248,7 +1252,7 @@ class WC_Shipcloud_Order
 	 */
 	public function get_sender($prefix = '') {
 		$options = $this->get_options();
-
+		
 		$sender = get_post_meta( $this->order_id, 'shipcloud_sender_address', true );
 
 		// Use default data if nothing was saved before
@@ -1259,12 +1263,12 @@ class WC_Shipcloud_Order
 				$prefix . 'last_name'  => $options['sender_last_name'],
 				$prefix . 'company'    => $options['sender_company'],
 				$prefix . 'street'     => $options['sender_street'],
-				$prefix . 'street_no'  => $options['sender_street_nr'],
+				$prefix . 'street_no'  => $options['sender_street_nr'] ?: $options['sender_street_no'],
 				$prefix . 'zip_code'   => $options['sender_postcode'] ?: $options['sender_zip_code'],
 				$prefix . 'city'       => $options['sender_city'],
 				$prefix . 'state'      => $options['sender_state'],
 				$prefix . 'country'    => $options['sender_country'],
-				$prefix . 'phone'      => $options['sender_phone'],
+				$prefix . 'phone'      => isset($options['sender_phone'])?:'',
 			);
 		}
 
@@ -1317,6 +1321,7 @@ class WC_Shipcloud_Order
 				$prefix . 'street'     => $recipient_street_name,
 				$prefix . 'street_no'  => $recipient_street_nr,
 				$prefix . 'zip_code'   => $order->shipping_postcode,
+				$prefix . 'postcode'   => $order->shipping_postcode,
 				$prefix . 'city'       => $order->shipping_city,
 				$prefix . 'state'      => $order->shipping_state,
 				$prefix . 'country'    => $order->shipping_country,
@@ -1398,7 +1403,7 @@ class WC_Shipcloud_Order
 			$data[ $prefix . 'zip_code' ] = $data[ $prefix . 'postcode' ];
 		}
 
-		return array_filter( $data );
+		return array_filter( $data, array(__CLASS__, 'filterArrayPreserveEmptyString') );
 	}
 
 	/**

--- a/components/woo/order.php
+++ b/components/woo/order.php
@@ -763,7 +763,7 @@ class WC_Shipcloud_Order
 
 				$title = trim( $data[ 'sender_company' ] ) != '' ? $data[ 'sender_company' ] . ', ' . $data[ 'sender_first_name' ] . ' ' . $data[ 'sender_last_name' ] : $data[ 'sender_first_name' ] . ' ' . $data[ 'sender_last_name' ];
 				$title .= ' <span class="dashicons dashicons-arrow-right-alt"></span> ';
-				if ( isset($data['recipient_company']) ) {
+				if ( !empty($data['recipient_company']) ) {
 					$title .= $data[ 'recipient_company' ] . ', ';
 				}
 				$title .= $data[ 'recipient_first_name' ] . ' ' . $data[ 'recipient_last_name' ];

--- a/components/woo/order.php
+++ b/components/woo/order.php
@@ -780,7 +780,7 @@ class WC_Shipcloud_Order
 					<div class="label-shipment-sender address">
 						<div class="sender_company"><?php echo $data[ 'sender_company' ]; ?></div>
 						<div class="sender_name"><?php echo $data[ 'sender_first_name' ]; ?> <?php echo $data[ 'sender_last_name' ]; ?></div>
-						<div class="sender_street"><?php echo $data[ 'sender_street' ]; ?> <?php echo $data[ 'sender_street_no' ]?: $data[ 'sender_street_nr' ]; ?></div>
+						<div class="sender_street"><?php echo $data[ 'sender_street' ]; ?> <?php echo (isset($data[ 'sender_street_nr' ])) ? $data[ 'sender_street_nr' ] : $data[ 'sender_street_no' ]; ?></div>
 						<div class="sender_city"><?php echo $data[ 'sender_zip_code' ]; ?> <?php echo $data[ 'sender_city' ]; ?></div>
 						<div class="sender_state"><?php echo $data[ 'sender_state' ]; ?></div>
 						<div class="sender_country"><?php echo (isset($data['country'])) ? $data[ 'country' ] : ''; ?></div>
@@ -789,7 +789,7 @@ class WC_Shipcloud_Order
 					<div class="label-shipment-recipient address">
 						<div class="recipient_company"><?php echo (isset($data['recipient_company'])) ? $data[ 'recipient_company' ] : ''; ?></div>
 						<div class="recipient_name"><?php echo $data[ 'recipient_first_name' ]; ?> <?php echo $data[ 'recipient_last_name' ]; ?></div>
-						<div class="recipient_street"><?php echo $data[ 'recipient_street' ]; ?> <?php echo $data[ 'recipient_street_no' ]?: $data[ 'recipient_street_nr' ]; ?></div>
+						<div class="recipient_street"><?php echo $data[ 'recipient_street' ]; ?> <?php echo (isset($data[ 'recipient_street_nr' ])) ? $data[ 'recipient_street_nr' ] : $data[ 'recipient_street_no' ]; ?></div>
 						<div class="recipient_city"><?php echo $data[ 'recipient_zip_code' ]; ?> <?php echo $data[ 'recipient_city' ]; ?></div>
 						<div class="recipient_state"><?php echo (isset($data['recipient_state'])) ? $data[ 'recipient_state' ] : ''; ?></div>
 						<div class="recipient_country"><?php echo $data[ 'recipient_country' ]; ?></div>

--- a/components/woo/order.php
+++ b/components/woo/order.php
@@ -822,7 +822,7 @@ class WC_Shipcloud_Order
 						<table>
 							<tbody>
 							<?
-								if ( (isset($data['recipient_company'])) ) {
+								if ( (isset($data['description']) && !empty($data['description'])) ) {
 							?>
 							<tr>
 								<th><?php _e( 'Shipment description', 'shipcloud-for-woocommerce' ); ?>:</th>

--- a/woocommerce-shipcloud-functions.php
+++ b/woocommerce-shipcloud-functions.php
@@ -250,13 +250,8 @@ function wcsc_is_settings_screen() {
 		$tab = $_GET['tab'];
 	}
 
-	$section = '';
-	if ( array_key_exists( 'section', $_GET ) ) {
-		$section = $_GET['section'];
-	}
-
 	// If page should noz show a message, interrupt the check and gibe back true
-	if ( 'wc-settings' === $page && 'shipping' === $tab && 'wc_shipcloud_shipping' === $section ) {
+	if ( 'wc-settings' === $page && 'shipping' === $tab && 'wc_shipcloud_shipping' === wcsc_get_section() ) {
 		return true;
 	}
 
@@ -329,7 +324,7 @@ function wcsc_is_admin_screen() {
 	}
 
 	// Settings screen
-	if ( 'shipcloud' === $_GET['section'] && 'woocommerce_page_wc-settings' === get_current_screen()->id ) {
+	if ( 'shipcloud' === wcsc_get_section() && 'woocommerce_page_wc-settings' === get_current_screen()->id ) {
 		return true;
 	}
 
@@ -462,6 +457,23 @@ function wcsc_api() {
 }
 
 $_wcsc_api = null;
+
+/**
+ * Get currently selected WooCommerce section
+ *
+ * @return string $section
+ *
+ * @since 1.5.0
+ */
+function wcsc_get_section() {
+	$section = '';
+
+	if ( array_key_exists( 'section', $_GET ) ) {
+		$section = $_GET['section'];
+	}
+
+	return $section;
+}
 
 /**
  * Connection to the API.


### PR DESCRIPTION
We've got a few minor bugs for reading and sanitizing data from an order. 

I've adjusted a few things to be accommodate those systems where the error reporting is set to `E_STRICT`. I've also included some fallbacks for data reading since we've renamed a few variables throughout history (see #84 for one of those fallbacks we need to resolve in the future). 

To be able to know if the current section selected is ours, I've also introduced a new function called `wcsc_get_section()` that handles this.