### PR TITLE
enhance handling of notification_email and advance_notice

### DIFF
--- a/components/woo/order.php
+++ b/components/woo/order.php
@@ -1648,8 +1648,8 @@ class WC_Shipcloud_Order
 			$data['notification_email'] = $this->get_notification_email();
 		}
 
-		if ( ( ! isset( $data['carrier'] ) || $data['carrier'] !== 'dpd' )
-			 && ( ! isset( $data['carrier'] ) || $data['carrier'] !== 'dhl' )
+		if ( ! isset( $data['carrier'] ) ||
+			 ( $data['carrier'] !== 'dpd' || $data['carrier'] !== 'dhl' )
 		) {
 			// Nothing we need to handle, so we early break here.
 			return $data;

--- a/components/woo/order.php
+++ b/components/woo/order.php
@@ -1007,8 +1007,8 @@ class WC_Shipcloud_Order
 			$order_id
 		);
 
-		$data['notification_email'] = $this->get_notification_email();
-		$data                      = $this->sanitize_shop_owner_data( $data );
+		$data = $this->sanitize_shop_owner_data( $data );
+		$data = $this->handle_email_notification( $data );
 
 		if ( array_key_exists( 'package', $data ) ) {
 			$data['package'] = $this->sanitize_package( $data['package'] );
@@ -1632,6 +1632,37 @@ class WC_Shipcloud_Order
 			'parcel'        => array( 'all' ),
 			'parcel_letter' => array( 'dhl', 'dpd' ),
 		);
+	}
+	
+	private function handle_email_notification( $data ) {
+		$carrier_email = $this->get_carrier_mail();
+		$notification_email = $this->get_notification_email();
+		
+		if ( $data['carrier'] == 'dpd' || $data['carrier'] == 'dhl' ) {
+			if ( ! empty ( $carrier_email ) ) {
+				unset($data['notification_email']);
+
+				$data['additional_services'] = array();
+	
+				$data['additional_services'] = array(
+					array(
+						'name'       => 'advance_notice',
+						'properties' => array(
+							'email'    => $carrier_email,
+							'language' => i18n_iso_convert( '3166-1-alpha-2', '639-1', strtoupper( $data['to']['country'] ) )
+						)
+					)
+				);
+			} elseif ( ! empty ( $notification_email ) ) {
+				$data['notification_email'] = $notification_email;
+			}
+		} else {
+			if ( ! empty ( $notification_email ) ) {
+				$data['notification_email'] = $this->get_notification_email();
+			}
+		}
+
+		return $data;
 	}
 }
 


### PR DESCRIPTION
This way pretty wild previously. I've changed the handling to be concise with the settings the user has made.

The following cases are handled now:
**Carrier is DHL or DPD**
- If `advance_notice` and `notification_email` have been activated, we will transmit advance_notice
- If `advance_notice` has been activated and `notification_email` has been deactivated we will transmit advance_notice
- If `advance_notice` has been deactivated and `notification_email` has been activated we will transmit notification_email
- If `advance_notice` and `notification_email` have been deactivated, we won't transmit either

**Carrier is on of 'the others'**
- If `advance_notice` and `notification_email` have been activated, we will transmit notification_email
- If `advance_notice` has been deactivated and `notification_email` has been activated then we will transmit notification_email
- If `advance_notice` has been activated and `notification_email` has been deactivated we won't transmit either
- If `advance_notice` and `notification_email` have been deactivated, we won't transmit either

Fixes #146 