### PR TITLE
Use shipping_parcelshop_post_number for care_of if present

### DIFF
--- a/components/woo/order.php
+++ b/components/woo/order.php
@@ -1375,6 +1375,11 @@ class WC_Shipcloud_Order
 			return (string) $order->shipping_address_2;
 		}
 
+		// check to see if WooCommerce germanized was used for supplying a post number
+		if ( $order->shipping_parcelshop_post_number) {
+			return (string) $order->shipping_parcelshop_post_number;
+		}
+
 		return (string) $order->billing_address_2;
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -114,6 +114,7 @@ https://youtu.be/HE3jow15x8c
 == Changelog ==
 
 = 1.5.0 =
+* Enhanced: When using the [WooCommerce germanized plugin](https://wordpress.org/plugins/woocommerce-germanized/) the post number for using DHL Packstation will be used for creating shipping labels instead of `shipping_address_2`
 * Fixed: Added whitespace between first and last name as well as street name and number when displaying a shipment
 * Fixed: `notification_email` is now transmitted correctly
 


### PR DESCRIPTION
When using the WooCommerce germanized plugin the field `shipping_parcelshop_post_number` for sending to a DHL Packstation will be used for creating shipping labels instead of `shipping_address_2`