### PR TITLE
Hotfix: Turn 'cod' into 'cash_on_delivery' when WGM is loaded

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,8 +3,8 @@
 = 1.5.1 =
 * Enhanced: added Belgium ISO country codes so users can send shipments via DPD to Belgium
 * Enhanced: Show minimum required versions for PHP and WooCommerce.
+* Enhanced: detect installed WooCommerce German Market plugin and detect cash on delivery orders differently
 * Fixed: `care_of` now displayed in shipment data and transmitted when updating a shipment
-* Fixed: WooCommerce German Market issues with cash on delivery payment
 
 = 1.5.0 =
 * Enhanced: When using the [WooCommerce germanized plugin](https://wordpress.org/plugins/woocommerce-germanized/) the post number for using DHL Packstation will be used for creating shipping labels instead of `shipping_address_2`

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Enhanced: added Belgium ISO country codes so users can send shipments via DPD to Belgium
 * Enhanced: Show minimum required versions for PHP and WooCommerce.
 * Fixed: `care_of` now displayed in shipment data and transmitted when updating a shipment
+* Fixed: WooCommerce German Market issues with cash on delivery payment
 
 = 1.5.0 =
 * Enhanced: When using the [WooCommerce germanized plugin](https://wordpress.org/plugins/woocommerce-germanized/) the post number for using DHL Packstation will be used for creating shipping labels instead of `shipping_address_2`

--- a/components/compatibility.php
+++ b/components/compatibility.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Watch for specific plugins and load compatibility if given.
+ */
+function wcsc_plugin_compatibility() {
+	foreach ( wp_get_active_and_valid_plugins() as $item ) {
+		// Turn "woocommerce-german-market/woocommerce-german-market.php" to slug "woocommerce-german-market"
+		$slug = basename( dirname( $item ) );
+
+		// Possible compatibility drop-in
+		$drop_in = __DIR__ . DIRECTORY_SEPARATOR . 'compatibility' . DIRECTORY_SEPARATOR . $slug . '.php';
+
+		if ( ! file_exists( $drop_in ) ) {
+			// Nothing for this plugin so we ignore it.
+			continue;
+		}
+
+		require_once $drop_in;
+	}
+
+	/**
+	 * Generic API for other plugins to hop in and change what we did.
+	 *
+	 * After WooCommerce Shipcloud has registered some function for compatibility reasons
+	 * we allow other plugins to manipulate this right afterwards.
+	 */
+	do_action( 'wcsc_plugin_compatibility' );
+}
+
+add_action( 'plugins_loaded', 'wcsc_plugin_compatibility' );

--- a/components/compatibility/woocommerce-german-market.php
+++ b/components/compatibility/woocommerce-german-market.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * WooCommerce German Market v2
+ *
+ * Please read the function documentations to find out which problems were solved here.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Wrong context!' );
+}
+
+/**
+ * Fix naming of cash on delivery payment.
+ *
+ * The cash on delivery payment gateway is simply named "cod" in WooCommerce.
+ * WGM renames this to "cash_on_delivery".
+ *
+ * @see \WooCommerce_Shipcloud::FILTER_GET_COD_ID
+ *
+ * @return string
+ */
+function wcsc_compat_woocommerce_german_market_cod() {
+	return 'cash_on_delivery';
+}
+
+add_filter( WooCommerce_Shipcloud::FILTER_GET_COD_ID, 'wcsc_compat_woocommerce_german_market_cod' );

--- a/components/woo/order-bulk.php
+++ b/components/woo/order-bulk.php
@@ -351,7 +351,7 @@ class WC_Shipcloud_Order_Bulk {
 			'create_shipping_label' => true,
 		);
 
-		if ( $order->get_wc_order() && 'cod' === $order->get_wc_order()->get_payment_method() ) {
+		if ( $order->get_wc_order() && wcsc_get_cod_id() === $order->get_wc_order()->get_payment_method() ) {
 			$cash_on_delivery = new \Shipcloud\Domain\Services\CashOnDelivery(
 				$order->get_wc_order()->get_total(),
 				$order->get_wc_order()->get_currency(),

--- a/components/woo/order.php
+++ b/components/woo/order.php
@@ -929,7 +929,7 @@ class WC_Shipcloud_Order
 		$data = $this->sanitize_shop_owner_data( $data );
 		$data = $this->handle_email_notification( $data );
 
-		if ( 'cod' === $order->get_payment_method() ) {
+		if ( wcsc_get_cod_id() === $order->get_payment_method() ) {
 		    $cash_on_delivery = new \Shipcloud\Domain\Services\CashOnDelivery(
                 $order->get_total(),
                 $order->get_currency(),

--- a/readme.txt
+++ b/readme.txt
@@ -119,6 +119,7 @@ https://youtu.be/HE3jow15x8c
 = 1.5.1 =
 * Enhanced: added Belgium ISO country codes so users can send shipments via DPD to Belgium
 * Enhanced: Show minimum required versions for PHP and WooCommerce.
+* Enhanced: detect installed WooCommerce German Market plugin and detect cash on delivery orders differently
 * Fixed: `care_of` now displayed in shipment data and transmitted when updating a shipment
 
 = 1.5.0 =

--- a/woocommerce-shipcloud-functions.php
+++ b/woocommerce-shipcloud-functions.php
@@ -616,3 +616,20 @@ function _wcsc_carriers_get() {
 
 	return $data;
 }
+
+/**
+ * Resolve the correct identifier for cash on delivery.
+ *
+ * @since 1.5.1 Due to plugins that rename the "cod" to something else.
+ *
+ * @return string
+ */
+function wcsc_get_cod_id() {
+	static $cod_id = null;
+
+	if ( null === $cod_id ) {
+		$cod_id = (string) apply_filters( WooCommerce_Shipcloud::FILTER_GET_COD_ID, 'cod' );
+	}
+
+	return $cod_id;
+}

--- a/woocommerce-shipcloud.php
+++ b/woocommerce-shipcloud.php
@@ -64,6 +64,8 @@ class WooCommerce_Shipcloud {
 	 */
 	const VERSION = '1.5.0';
 
+	const FILTER_GET_COD_ID = 'wcsc_get_cod_id';
+
 	/**
 	 * Construct
 	 *
@@ -504,6 +506,7 @@ spl_autoload_register( '\\WooCommerce_Shipcloud::load_vendor' );
 spl_autoload_register( '\\WooCommerce_Shipcloud::load_shipcloud' );
 
 require_once __DIR__ . '/components/service-container.php';
+require_once __DIR__ . '/components/compatibility.php';
 
 
 /**


### PR DESCRIPTION
What has changed?

- wcsc_get_cod_id function
- uses filter to allow manipulation
- compatibility for WGM



## Things to review

Common things:

- [x] Works fine.
- [x] Changelog written or not needed.
- [ ] In case of bugfix also merged in other minor versions.
- [x] No conflict with current branch.

Got an idea while looking at the GUI?
Please [add a new issue refering to this one.](https://github.com/awsmug/shipcloud-for-woocommerce/issues/new?title=Idea&body=While%20looking%20at%20issue%20)



