### PR TITLE
Have only one object of the API and inject elsewhere

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 == Changelog ==
 
+= 1.6.0 =
+* Enhanced: API connections optimized/centralized.
+
 = 1.5.1 =
 * Enhanced: added Belgium ISO country codes so users can send shipments via DPD to Belgium
 * Enhanced: Show minimum required versions for PHP and WooCommerce.

--- a/components/core/parcel-template.php
+++ b/components/core/parcel-template.php
@@ -71,6 +71,13 @@ class WCSC_Parceltemplate_Posttype
 	}
 
 	/**
+	 * @return array|mixed
+	 */
+	protected static function get_api() {
+		return _wcsc_container()->get( '\\Woocommerce_Shipcloud_API' );
+	}
+
+	/**
 	 * Main Instance
 	 *
 	 * @since 1.0.0
@@ -173,8 +180,7 @@ class WCSC_Parceltemplate_Posttype
 			return;
 		}
 
-		$shipcloud_api = new Woocommerce_Shipcloud_API( wcsc_shipping_method()->get_option( 'api_key' ) );
-		$shipcloud_carriers = $shipcloud_api->get_carriers();
+		$shipcloud_carriers = self::get_api()->get_carriers();
 
 		$carriers = array();
 		foreach( $shipcloud_carriers AS $carrier )

--- a/components/service-container.php
+++ b/components/service-container.php
@@ -25,7 +25,17 @@ if ( is_admin() && get_current_user() ) {
 			},
 			'\\Shipcloud\\Repository\\ShipmentRepository' => function () {
 				return new \Shipcloud\Repository\ShipmentRepository();
-			}
+			},
+			'\\Woocommerce_Shipcloud_API' => function () {
+				$options = get_option( 'woocommerce_shipcloud_settings' );
+
+				$api_key = null;
+				if ( isset( $options['api_key'] ) ) {
+					$api_key = $options['api_key'];
+				}
+
+				return new Woocommerce_Shipcloud_API( $api_key );
+			},
 		)
 	);
 }

--- a/components/woo/order.php
+++ b/components/woo/order.php
@@ -169,6 +169,15 @@ class WC_Shipcloud_Order
 	}
 
 	/**
+     * @deprecated 2.0.0 The API should be fully injected instead of fetched from the container.
+     *
+	 * @return \Woocommerce_Shipcloud_API
+	 */
+	protected function get_api() {
+		return _wcsc_container()->get( '\\Woocommerce_Shipcloud_API' );
+	}
+
+	/**
 	 * Main Instance
 	 *
 	 * @since 1.0.0
@@ -830,9 +839,6 @@ class WC_Shipcloud_Order
 	 */
 	public function ajax_calculate_shipping()
 	{
-		$options       = $this->get_options();
-		$shipcloud_api = new Woocommerce_Shipcloud_API( $options[ 'api_key' ] );
-
 		$package = array(
 			'width'  => wc_format_decimal( $_POST['package'][ 'width' ] ),
 			'height' => wc_format_decimal( $_POST['package'][ 'height' ] ),
@@ -841,7 +847,7 @@ class WC_Shipcloud_Order
             'type' => $_POST['package']['type'],
 		);
 
-		$price = $shipcloud_api->get_price(
+		$price = $this->get_api()->get_price(
 		        $_POST[ 'carrier' ],
                 $_POST['from'],
                 $_POST['to'],
@@ -1034,9 +1040,6 @@ class WC_Shipcloud_Order
 	 * @return array|WP_Error
 	 */
 	public function create_label( $order_id, $carrier_id, $shipment_id = null ) {
-		$options       = $this->get_options();
-		$shipcloud_api = new Woocommerce_Shipcloud_API( $options['api_key'] );
-
 		$order = wc_get_order( $order_id );
 
 		/** @var \Shipcloud\Repository\ShipmentRepository $shipmentRepo */
@@ -1047,7 +1050,7 @@ class WC_Shipcloud_Order
 		    $params = $shipmentRepo->findByShipmentId( $order_id, $shipment_id );
         }
 
-		$request = $shipcloud_api->create_label( $shipment_id, $params );
+		$request = $this->get_api()->create_label( $shipment_id, $params );
 
 		if ( is_wp_error( $request ) ) {
 			$error_message = $request->get_error_message();
@@ -1181,10 +1184,7 @@ class WC_Shipcloud_Order
 	 */
 	private function get_tracking_status_html( $shipment_id )
 	{
-		$settings      = $this->get_options();
-		$shipcloud_api = new Woocommerce_Shipcloud_API( $settings[ 'api_key' ] );
-
-		$shipcloud_api->get_tracking_status( $shipment_id );
+		$this->get_api()->get_tracking_status( $shipment_id );
 	}
 
 	/**

--- a/components/woo/shipping-method.php
+++ b/components/woo/shipping-method.php
@@ -123,18 +123,18 @@ class WC_Shipcloud_Shipping extends WC_Shipping_Method
 	 * Initialize Shipcloud API
 	 *
 	 * @since 1.1.0
+	 *
+	 * @param null $api_key DEPRECATED since 1.6.0 as API gets fully injected by service container.
+	 *
+	 * @return bool|WP_Error
 	 */
 	private function init_shipcloud_api( $api_key = null ){
 		if( is_object( $this->shipcloud_api ) ) {
 			return true;
 		}
 
-		if( empty( $api_key ) ) {
-			$api_key = $this->get_option( 'api_key' );
-		}
-
 		// Initializing
-		$this->shipcloud_api = new Woocommerce_Shipcloud_API( $api_key );
+		$this->shipcloud_api = _wcsc_container()->get( '\\Woocommerce_Shipcloud_API' );
 
 		if( ! $this->shipcloud_api->is_valid() ) {
 		    $error = new WP_Error(

--- a/includes/shipcloud/shipcloud.php
+++ b/includes/shipcloud/shipcloud.php
@@ -66,19 +66,7 @@ class Woocommerce_Shipcloud_API
 	public function __construct( $api_key = null )
 	{
 		$this->settings = get_option( 'woocommerce_shipcloud_settings' );
-
-		if ( null !== $api_key )
-		{
-			$this->api_key = $api_key;
-		}
-
-		if ( empty( $this->settings[ 'api_key' ] ) )
-		{
-			// No API key anywhere - stop here.
-			return;
-		}
-
-		$this->api_key = $this->settings[ 'api_key' ];
+		$this->api_key = $api_key;
 
 		$this->api_url = 'https://api.shipcloud.io/v1';
 

--- a/readme.txt
+++ b/readme.txt
@@ -116,6 +116,9 @@ https://youtu.be/HE3jow15x8c
 
 == Changelog ==
 
+= 1.6.0 =
+* Enhanced: API connections optimized/centralized.
+
 = 1.5.1 =
 * Enhanced: added Belgium ISO country codes so users can send shipments via DPD to Belgium
 * Enhanced: Show minimum required versions for PHP and WooCommerce.

--- a/woocommerce-shipcloud-functions.php
+++ b/woocommerce-shipcloud-functions.php
@@ -443,17 +443,7 @@ add_filter( 'woocommerce_shipping_fields', 'wcsc_sender_phone_frontend' );
  * @return Woocommerce_Shipcloud_API
  */
 function wcsc_api() {
-	static $api;
-
-	if ( ! $api ) {
-		if ( wcsc_shipping_method() ) {
-			$api_key = wcsc_shipping_method()->get_option( 'api_key' );
-		}
-
-		$api = new Woocommerce_Shipcloud_API( $api_key );
-	}
-
-	return $api;
+	return _wcsc_container()->get( '\\Woocommerce_Shipcloud_API' );
 }
 
 $_wcsc_api = null;


### PR DESCRIPTION
The issue was that multiple invocations of one class lay around
which took to long to maintain.
Therefor it is shifted into a service container
so that we have it only one time in a central place.

- Except for tests.
- Inner api key logic is therefor removed
  as the container takes care of this.

Please read the commit messages for details.

## Things to review

Common things:

- [x] Works fine.
- [x] Changelog written or not needed.
- [x] In case of bugfix also merged in other minor versions.
- [x] No conflict with current branch.

Got an idea while looking at the GUI?
Please [add a new issue refering to this one.](https://github.com/awsmug/shipcloud-for-woocommerce/issues/new?title=Idea&body=While%20looking%20at%20issue%20)



