### PR TITLE
add function for handling action links

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 == Changelog ==
 
+= 1.6.0 =
+* Enhanced: Add action link so users can jump from plugins page directly to the plugin settings
+
 = 1.5.1 =
 * Enhanced: added Belgium ISO country codes so users can send shipments via DPD to Belgium
 * Enhanced: Show minimum required versions for PHP and WooCommerce.

--- a/readme.txt
+++ b/readme.txt
@@ -116,6 +116,9 @@ https://youtu.be/HE3jow15x8c
 
 == Changelog ==
 
+= 1.6.0 =
+* Enhanced: Add action link so users can jump from plugins page directly to the plugin settings
+
 = 1.5.1 =
 * Enhanced: added Belgium ISO country codes so users can send shipments via DPD to Belgium
 * Enhanced: Show minimum required versions for PHP and WooCommerce.

--- a/woocommerce-shipcloud.php
+++ b/woocommerce-shipcloud.php
@@ -519,3 +519,19 @@ function woocommerce_shipcloud_init() {
 }
 
 add_action( 'plugins_loaded', 'woocommerce_shipcloud_init' );
+
+/**
+ * handle plugin action links
+ *
+ * @since 1.6.0
+ *
+ * @return string
+ */
+function wcsc_action_links( $links ) {
+	$action_links = array(
+		'settings' => '<a href="' . admin_url( 'admin.php?page=wc-settings&tab=shipping&section=shipcloud' ) . '" aria-label="' . esc_attr__( 'Settings', 'shipcloud-for-woocommerce' ) . '">' . esc_html__( 'Settings', 'shipcloud-for-woocommerce' ) . '</a>',
+	);
+	return array_merge( $links, $action_links );
+}
+
+add_filter( 'plugin_action_links_' . plugin_basename(__FILE__), 'wcsc_action_links' );


### PR DESCRIPTION
What has changed?
- users can now jump from the plugins page directly into the plugin settings

Please read the commit messages for details.

## Things to review
- Link in plugin settings is shown and redirects to the shipcloud settings in WooCommerce

Common things:
- [x] Works fine.
- [x] Changelog written or not needed.
- [x] No conflict with current branch.
