### PR TITLE
Hotfix: Remove some transients on plugin (de-)activation

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.6.0 =
 * Enhanced: Add action link so users can jump from plugins page directly to the plugin settings
+* Fixed: Flush carriers on plugin (de-)activation to manually invalidate the cache.
 
 = 1.5.1 =
 * Enhanced: added Belgium ISO country codes so users can send shipments via DPD to Belgium

--- a/readme.txt
+++ b/readme.txt
@@ -118,6 +118,7 @@ https://youtu.be/HE3jow15x8c
 
 = 1.6.0 =
 * Enhanced: Add action link so users can jump from plugins page directly to the plugin settings
+* Fixed: Flush carriers on plugin (de-)activation to manually invalidate the cache.
 
 = 1.5.1 =
 * Enhanced: added Belgium ISO country codes so users can send shipments via DPD to Belgium

--- a/woocommerce-shipcloud.php
+++ b/woocommerce-shipcloud.php
@@ -196,6 +196,10 @@ class WooCommerce_Shipcloud {
 	public static function activate( $network_wide ) {
 	}
 
+	protected static function delete_transients() {
+		delete_transient( '_wcsc_carriers_get' );
+	}
+
 	/**
 	 * Fired when the plugin is deactivated.
 	 *
@@ -204,6 +208,8 @@ class WooCommerce_Shipcloud {
 	 */
 	public static function deactivate( $network_wide ) {
 		delete_option( 'woocommerce_shipcloud_carriers' );
+
+		static::delete_transients();
 	}
 
 	/**


### PR DESCRIPTION
What has changed?

- Transienst will be deleted on plugin (de-)activation


Please read the commit messages for details.

## Things to review

Common things:

- [ ] Works fine.
- [x] Changelog written or not needed.
- [x] No conflict with current branch.

Got an idea while looking at the GUI?
Please [add a new issue refering to this one.](https://github.com/awsmug/shipcloud-for-woocommerce/issues/new?title=Idea&body=While%20looking%20at%20issue%20)



