### PR TITLE
add an input field for supplying the parameter declared_value

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 == Changelog ==
 
+= 1.6.2 =
+* Fixed: (Re)Added an input field for providing a value to book a higher insurance with the carrier
+
 = 1.6.1 =
 * Fixed: Problems with shop guests and cart usage fixed.
 

--- a/components/block/label-form.php
+++ b/components/block/label-form.php
@@ -30,6 +30,16 @@
         </td>
     </tr>
     <tr>
+        <th>
+          <?php _e( 'Higher insurance', 'shipcloud-for-woocommerce' ); ?>
+          <?php echo wc_help_tip( __( 'Use this to book additional insurance or expand the liability for a shipment. Caution: Please keep in mind that additional fees are charged by the carrier', 'shipcloud-for-woocommerce' ) ); ?>
+        </th>
+        <td>
+          <input type="text" name="declared_value"
+            class="lengths"/> <?php _e( 'EUR', 'shipcloud-for-woocommerce' ); ?>
+        </td>
+    </tr>
+    <tr>
         <th><?php _e( 'Shipping method', 'shipcloud-for-woocommerce' ); ?></th>
         <td>
 			<?php if ( count( $this->get_allowed_carriers() ) > 0 ): ?>

--- a/components/woo/order.php
+++ b/components/woo/order.php
@@ -282,6 +282,10 @@ class WC_Shipcloud_Order
 		$package_data['height'] = wc_format_decimal( $package_data['height'] );
 		$package_data['length'] = wc_format_decimal( $package_data['length'] );
 		$package_data['weight'] = wc_format_decimal( $package_data['weight'] );
+		
+		if( array_key_exists('declared_value', $package_data) ) {
+			$package_data['declared_value']['amount'] = wc_format_decimal( $package_data['declared_value']['amount'] );
+		}
 
 		return $package_data;
 	}

--- a/includes/js/shipcloud-label-form.js
+++ b/includes/js/shipcloud-label-form.js
@@ -42,14 +42,22 @@ shipcloud.LabelForm = function (wrapperSelector) {
     };
 
     this.getPackage = function () {
-        return {
-            'width'      : $('input[name="parcel_width"]', self.$wrapper).val(),
-            'height'     : $('input[name="parcel_height"]', self.$wrapper).val(),
-            'length'     : $('input[name="parcel_length"]', self.$wrapper).val(),
-            'weight'     : $('input[name="parcel_weight"]', self.$wrapper).val(),
-            'description': $('input[name="parcel_description"]', self.$wrapper).val(),
-            'type'       : $('select[name="shipcloud_carrier_package"]', self.$wrapper).val()
-        }
+      var package_hash = {
+        'width'      : $('input[name="parcel_width"]', self.$wrapper).val(),
+        'height'     : $('input[name="parcel_height"]', self.$wrapper).val(),
+        'length'     : $('input[name="parcel_length"]', self.$wrapper).val(),
+        'weight'     : $('input[name="parcel_weight"]', self.$wrapper).val(),
+        'description': $('input[name="parcel_description"]', self.$wrapper).val(),
+        'type'       : $('select[name="shipcloud_carrier_package"]', self.$wrapper).val()
+      };
+
+      if ($('input[name="declared_value"]', self.$wrapper).val()) {
+        package_hash['declared_value'] = {
+          'amount'   : $('input[name="declared_value"]', self.$wrapper).val(),
+          'currency' : 'EUR'
+        };
+      }
+      return package_hash;
     };
 
     self.getCarrier = function () {

--- a/readme.txt
+++ b/readme.txt
@@ -116,6 +116,9 @@ https://youtu.be/HE3jow15x8c
 
 == Changelog ==
 
+= 1.6.2 =
+* Fixed: (Re)Added an input field for providing a value to book a higher insurance with the carrier
+
 = 1.6.1 =
 * Fixed: Problems with shop guests and cart usage fixed.
 


### PR DESCRIPTION
**What has changed?**
- added an input field for supplying a value for [additional insurance](https://developers.shipcloud.io/examples/#dhl-additional-insurance)
- also added a tooltip, because this feature can result in a higher charge for the customer

## Things to review

Common things:

- [x] Works fine.
- [x] Changelog written or not needed.
- [x] No conflict with current branch.