### PR TITLE
make sure that the advance_notice service only gets booked if we can …

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 == Changelog ==
 
+= 1.6.2 =
+* Fixed: Error message when ISO language code couldn't be determined
+
 = 1.6.1 =
 * Fixed: Problems with shop guests and cart usage fixed.
 

--- a/components/woo/order.php
+++ b/components/woo/order.php
@@ -1682,6 +1682,11 @@ class WC_Shipcloud_Order
 				$data['additional_services'] = array();
 			}
 
+			if ( ! isset( $data['to']['country'] ) ) {
+			    // Might not be set in return labels.
+				$data['to']['country'] = '';
+			}
+
 			// Append advance notice service.
 			$advance_notice_language =
 				i18n_iso_convert( '3166-1-alpha-2', '639-1', strtoupper( $data['to']['country'] ) );

--- a/components/woo/order.php
+++ b/components/woo/order.php
@@ -1683,13 +1683,18 @@ class WC_Shipcloud_Order
 			}
 
 			// Append advance notice service.
-			$data['additional_services'][] = array(
-				'name'       => 'advance_notice',
-				'properties' => array(
-					'email'    => $carrier_email,
-					'language' => i18n_iso_convert( '3166-1-alpha-2', '639-1', strtoupper( $data['to']['country'] ) )
-				)
-			);
+			$advance_notice_language =
+				i18n_iso_convert( '3166-1-alpha-2', '639-1', strtoupper( $data['to']['country'] ) );
+
+			if( $advance_notice_language ) {
+				$data['additional_services'][] = array(
+					'name'       => 'advance_notice',
+					'properties' => array(
+						'email'    => $carrier_email,
+						'language' => $advance_notice_language
+					)
+				);
+			}
 
 			if ( isset( $data['notification_email'] ) ) {
 				// No need for notification mail after advance_notice has been added.

--- a/readme.txt
+++ b/readme.txt
@@ -41,7 +41,6 @@ receive their order from
 * FedEx
 * TNT
 * GO! (General Overnight)
-* Liefery
 
 = Additional services* =
 
@@ -115,6 +114,9 @@ https://youtu.be/HE3jow15x8c
 8. Adjust sender and/or receiver addresses base on your current use case
 
 == Changelog ==
+
+= 1.6.2 =
+* Fixed: Error message when ISO language code couldn't be determined
 
 = 1.6.1 =
 * Fixed: Problems with shop guests and cart usage fixed.


### PR DESCRIPTION
…determine the language

fixes #172

What has changed?
- We're now checking to see if we were able to determine the language before adding `advance_notice` to a shipment request.

## Things to review

Common things:

- [x] Works fine.
- [x] Changelog written or not needed.
- [x] No conflict with current branch.