### PR TITLE
fix missing tracking url link

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 1.6.3 =
 * Enhanced: Removed buttons for creating/preparing return shipments, because you can select returns as a service
 * Fixed: empty destination zip_code in checkout
+* Fixed: missing tracking url link
 
 = 1.6.2 =
 * Enhanced: Added more countries and their respective languages to the I18n Mapping.

--- a/components/block/order-label-template.php
+++ b/components/block/order-label-template.php
@@ -70,7 +70,7 @@
                 <# } #>
 
                 <# if ( data.model.get('tracking_url') ) { #>
-                <a href="{{ data.model.get('tracking_url') }}" target="_blank" class="button">
+                <a href="{{ data.model.getCarrierTrackingUrl() }}" target="_blank" class="button">
                     <?php _e( 'Tracking link', 'shipcloud-for-woocommerce' ); ?>
                 </a>
                 <# } #>
@@ -107,7 +107,11 @@
                     <# if ( data.model.get('id') ) { #>
                     <tr>
                         <th><?php _e( 'Shipment id:', 'shipcloud-for-woocommerce' ); ?></th>
-                        <td>{{ data.model.get('id') }}</td>
+                        <td>
+                          <a href="{{ data.model.get('tracking_url') }}" target="_blank">
+                            {{ data.model.get('id') }}
+                          </a>
+                        </td>
                     </tr>
                     <# } #>
                     <# if ( data.model.get('label_url') ) { #>
@@ -115,7 +119,9 @@
                         <th><?php _e( 'Tracking number:', 'shipcloud-for-woocommerce' ); ?></th>
                         <td class="tracking-number">
                             <# if ( data.model.get('carrier_tracking_no') ) { #>
-                                {{ data.model.get('carrier_tracking_no') }}
+                                <a href="{{ data.model.get('carrier_tracking_url') }}" target="_blank">
+                                  {{ data.model.get('carrier_tracking_no') }}
+                                </a>
                             <# } else { #>
                                 <?php _e( 'Not available yet', 'shipcloud-for-woocommerce' ); ?>
                             <# } #>

--- a/includes/js/shipcloud-shipments.js
+++ b/includes/js/shipcloud-shipments.js
@@ -71,7 +71,8 @@ shipcloud.ShipmentModel = Backbone.Model.extend({
         'notification_email'        : null,
         'price'                     : null,
         'shipper_notification_email': null,
-        'tracking_url'              : null
+        'tracking_url'              : null,
+        'carrier_tracking_url'      : null
     },
 
     getData: function () {
@@ -154,6 +155,41 @@ shipcloud.ShipmentModel = Backbone.Model.extend({
 
     getTitle: function () {
         return _.filter([this.get('carrier'), this.get('package').getTitle()]).join(' ');
+    },
+
+    getCarrierTrackingUrl: function () {
+      var carrierTrackingUrl;
+      switch (this.get('carrier')) {
+        case 'dhl':
+          carrierTrackingUrl = 'https://nolp.dhl.de/nextt-online-public/set_identcodes.do?idc=' + this.get('carrier_tracking_no') + '&rfn=&extendedSearch=true';
+          break;
+        case 'dpd':
+          carrierTrackingUrl = 'https://tracking.dpd.de/parcelstatus?query=' + this.get('carrier_tracking_no') + '&locale=de_DE';
+          break;
+        case 'fedex':
+          carrierTrackingUrl = 'https://www.fedex.com/apps/fedextrack/?action=track&trackingnumber=' + this.get('carrier_tracking_no');
+          break;
+        case 'gls':
+          carrierTrackingUrl = 'https://gls-group.eu/DE/de/paketverfolgung?match=' + this.get('carrier_tracking_no');
+          break;
+        case 'go':
+          carrierTrackingUrl = 'https://order.general-overnight.com/ax4/control/customer_service?shId=' + this.get('carrier_tracking_no') + '&hash=JMJyKOfE1v&lang=de&ActionCollectInformation=GO%21';
+          break;
+        case 'hermes':
+          carrierTrackingUrl = 'https://tracking.hermesworld.com/?TrackID=' + this.get('carrier_tracking_no');
+          break;
+        case 'iloxx':
+          carrierTrackingUrl = 'http://www.iloxx.de/net/einzelversand/tracking.aspx?ix=' + this.get('carrier_tracking_no');
+          break;
+        case 'tnt':
+          carrierTrackingUrl = 'https://www.tnt.com/express/de_de/site/home/applications/tracking.html?cons=' + this.get('carrier_tracking_no') + '&searchType=CON';
+          break;
+        case 'ups':
+          carrierTrackingUrl = 'http://wwwapps.ups.com/WebTracking/processInputRequest?sort_by=status&' + this.get('carrier_tracking_no') + '=1&TypeOfInquiryNumber=T&loc=de_DE&InquiryNumber1=' + this.get('carrier_tracking_no') + '&track.x=' + this.get('carrier_tracking_no') + '&track.y=0';
+          break;
+      }
+      this.set('carrier_tracking_url', carrierTrackingUrl);
+      return carrierTrackingUrl;
     }
 })
 ;

--- a/includes/shipcloud/repository/shipmentrepository.php
+++ b/includes/shipcloud/repository/shipmentrepository.php
@@ -111,6 +111,7 @@ class ShipmentRepository {
 				//'type' => $_POST['package']['type'],
 			),
 			'label_url'           => isset($old_structured_data['label_url']) ? $old_structured_data['label_url'] : '',
+			'tracking_url'        => isset($old_structured_data['tracking_url']) ? $old_structured_data['tracking_url'] : '',
 			'price'               => isset($old_structured_data['price']) ? $old_structured_data['price'] : '',
 			'carrier'             => isset($old_structured_data['carrier']) ? $old_structured_data['carrier'] : '',
 			'carrier_tracking_no' => isset($old_structured_data['carrier_tracking_no']) ? $old_structured_data['carrier_tracking_no'] : '',

--- a/readme.txt
+++ b/readme.txt
@@ -118,6 +118,7 @@ https://youtu.be/HE3jow15x8c
 = 1.6.3 =
 * Enhanced: Removed buttons for creating/preparing return shipments, because you can select returns as a service
 * Fixed: empty destination zip_code in checkout
+* Fixed: missing tracking url link
 
 = 1.6.2 =
 * Enhanced: Added more countries and their respective languages to the I18n Mapping.


### PR DESCRIPTION
What has changed?

- URL to shipcloud tracking page was missing. Readded it.
- Also added a direct link to the carrier tracking page.