### PR TITLE
Fixes marathon for WooCommerce 2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,13 @@
 == Changelog ==
 
+= 1.6.4 =
+* Enhanced: Rework handling of WP_Error when deleting a shipment
+* Enhanced: Added method to shipment model so we can output error messages to the UI
+* Fixed: Standard carrier caused problems in checkout when buyer was selecting the shipping carrier.
+* Fixed: Added handling of undefined parcel, sender and shipment data
+* Fixed: Added backwards compatibility for getting the payment method (to check for cash on delivery)
+* Removed: Standard carrier from settings.
+
 = 1.6.3 =
 * Enhanced: Removed buttons for creating/preparing return shipments, because you can select returns as a service
 * Enhanced: Make it possible to supply a reference_number before creating a shipment

--- a/components/woo/order-bulk.php
+++ b/components/woo/order-bulk.php
@@ -47,6 +47,22 @@ class WC_Shipcloud_Order_Bulk {
 	}
 
 	/**
+     * Backward compatibility to WC2.
+     *
+	 * The current WC3 has almost anything covered by getter methods
+	 * while the old WC2 used simple fields for that.
+	 * This layer allows using the old syntax
+	 * and makes it compatible with the new one.
+     *
+	 * @param $name
+	 *
+	 * @return bool
+	 */
+	public function __isset( $name ) {
+		return property_exists( '\\WC_Order', $name ) || method_exists( $this->get_wc_order(), 'get_' . $name );
+	}
+	
+	/**
 	 * Initializing hooks and filters
 	 *
 	 * @since   1.2.1
@@ -351,10 +367,10 @@ class WC_Shipcloud_Order_Bulk {
 			'create_shipping_label' => true,
 		);
 
-		if ( $order->get_wc_order() && wcsc_get_cod_id() === $order->get_wc_order()->get_payment_method() ) {
+		if ( $order->get_wc_order() && wcsc_get_cod_id() === $order->__get('payment_method') ) {
 			$cash_on_delivery = new \Shipcloud\Domain\Services\CashOnDelivery(
 				$order->get_wc_order()->get_total(),
-				$order->get_wc_order()->get_currency(),
+				$order->__get('currency'),
 				$order->get_bank_information(),
 				sprintf( __( 'WooCommerce OrderID: %s', 'shipcloud-for-woocommerce' ), $order_id )
 			);
@@ -374,7 +390,7 @@ class WC_Shipcloud_Order_Bulk {
 
 			$order->get_wc_order()->add_order_note( __( 'shipcloud.io label was created.', 'woocommerce-shipcloud' ) );
 
-			WC_Shipcloud_Shipping::log( 'Order #' . $order->get_wc_order()->get_order_number() . ' - Created shipment successful (' . wcsc_get_carrier_display_name( $request['carrier'] ) . ')' );
+			WC_Shipcloud_Shipping::log( 'Order #' . $order->get_wc_order()->get_order_number() . ' - Created shipment successful (' . wcsc_get_carrier_display_name( $request['shipcloud_carrier'] ) . ')' );
 
 			$parcel_title = wcsc_get_carrier_display_name( $request['shipcloud_carrier'] )
 							. ' - '

--- a/components/woo/shipping-classes.php
+++ b/components/woo/shipping-classes.php
@@ -325,10 +325,10 @@ class WC_Shipcloud_Shippig_Classes
 	 */
 	public function shipping_class_edit_form_fields_save( $term_id )
 	{
-		$parcel_length = $_POST[ 'shipcloud_parcel_length' ];
-		$parcel_width  = $_POST[ 'shipcloud_parcel_width' ];
-		$parcel_height = $_POST[ 'shipcloud_parcel_height' ];
-		$parcel_weight = $_POST[ 'shipcloud_parcel_weight' ];
+		$parcel_length = $_POST[ 'shipcloud_parcel_length' ] ?: '';
+		$parcel_width  = $_POST[ 'shipcloud_parcel_width' ] ?: '';
+		$parcel_height = $_POST[ 'shipcloud_parcel_height' ] ?: '';
+		$parcel_weight = $_POST[ 'shipcloud_parcel_weight' ] ?: '';
 
 		update_option( 'shipping_class_' . $term_id . '_shipcloud_length', $parcel_length );
 		update_option( 'shipping_class_' . $term_id . '_shipcloud_width', $parcel_width );

--- a/includes/css/admin.css
+++ b/includes/css/admin.css
@@ -388,3 +388,10 @@ fieldset .shipment-labels .address {
 #wscs_order_bulk_pdf {
     margin-right: 0.5em;
 }
+
+/**
+ * Bulk
+ */
+#shipcloud_bulk .parcel-form-table th {
+  width: 25%;
+}

--- a/includes/js/bulk-order-label.js
+++ b/includes/js/bulk-order-label.js
@@ -83,9 +83,9 @@ wcsc.OrderBulkLabels = function (submitButton) {
     this.setBulk = function () {
         self.populateTitles();
 
-        $('td', self.bulkScreen).attr('colspan', $('th:visible, td:visible', '.widefat:first thead').length);
+        $('> td', self.bulkScreen).attr('colspan', $('th:visible, td:visible', '.widefat:first thead').length);
         // Insert the editor at the top of the table with an empty row above to maintain zebra striping.
-        $('table.widefat tbody').prepend($(self.bulkScreen)).prepend('<tr class="hidden"></tr>');
+        $('table.wp-list-table.widefat > tbody').prepend($(self.bulkScreen)).prepend('<tr class="hidden"></tr>');
         $(self.bulkScreen).show();
         $('.shipcloud-carrier-select', self.bulkScreen).shipcloudMultiSelect(wcsc_carrier);
 

--- a/includes/js/shipcloud-shipments.js
+++ b/includes/js/shipcloud-shipments.js
@@ -125,7 +125,7 @@ shipcloud.ShipmentModel = Backbone.Model.extend({
                 var result = JSON.parse(response);
 
                 if (result.status === 'ERROR') {
-                    print_errors(result.errors);
+                    self.printErrors(result.errors);
 
                     return;
                 }
@@ -133,8 +133,7 @@ shipcloud.ShipmentModel = Backbone.Model.extend({
                 self.trigger('destroy');
             }
         );
-    }
-    ,
+    },
 
     parse: function (data) {
         if (data.hasOwnProperty('from')) {
@@ -150,8 +149,7 @@ shipcloud.ShipmentModel = Backbone.Model.extend({
         }
 
         return data;
-    }
-    ,
+    },
 
     getTitle: function () {
         return _.filter([this.get('carrier'), this.get('package').getTitle()]).join(' ');
@@ -190,6 +188,21 @@ shipcloud.ShipmentModel = Backbone.Model.extend({
       }
       this.set('carrier_tracking_url', carrierTrackingUrl);
       return carrierTrackingUrl;
+    },
+
+    printErrors: function (errors) {
+      if (typeof errors === 'string') {
+        // Received single error message, so we convert it to the expected format.
+        errors = [errors];
+      }
+
+      var html = '<div class="error"><ul class="errors">';
+      errors.forEach(function (entry) {
+        html += '<li>' + entry + '</li>';
+      });
+      html += '</ul></div>';
+
+      jQuery('#shipment-center').find('.info').fadeIn().html(html);
     }
 })
 ;

--- a/includes/shipcloud/domain/shipment.php
+++ b/includes/shipcloud/domain/shipment.php
@@ -18,8 +18,6 @@ class Shipment {
 	private $price;
 
 	private $tracking_url;
-	
-	private $reference_number;
 
 	/**
 	 * Shipment constructor.
@@ -30,6 +28,7 @@ class Shipment {
 	 * @param string $label_url           URL where you can download the label in PDF format.
 	 * @param double $price               Price that we're going to charge you (exl. VAT).
 	 * @param string $carrier_tracking_no The original tracking number that can be used on the carriers website.
+	 * @param string $reference_number    A reference number provided by the admin
 	 */
 	public function __construct( $id, $tracking_url, $label_url, $price, $carrier_tracking_no = null ) {
 		$this->id                  = $id;
@@ -37,7 +36,6 @@ class Shipment {
 		$this->label_url           = $label_url;
 		$this->price               = $price;
 		$this->carrier_tracking_no = $carrier_tracking_no;
-		$this->reference_number    = $reference_number;
 	}
 
 	/**
@@ -52,11 +50,10 @@ class Shipment {
 
 		return new static(
 			$shipment['id'],
-			$shipment['tracking_url'],
-			$shipment['label_url'],
-			$shipment['price'],
-			$shipment['carrier_tracking_no'],
-			$shipment['reference_number']
+			$shipment['tracking_url'] ?: null,
+			$shipment['label_url'] ?: null,
+			$shipment['price'] ?: null,
+			$shipment['carrier_tracking_no'] ?: null
 		);
 	}
 
@@ -93,12 +90,5 @@ class Shipment {
 	 */
 	public function getTrackingUrl() {
 		return $this->tracking_url;
-	}
-	
-		/**
-		 * @return string
-		 */
-	public function getReferenceNumber() {
-		return $this->reference_number;
 	}
 }

--- a/includes/shipcloud/shipmentadapter.php
+++ b/includes/shipcloud/shipmentadapter.php
@@ -59,7 +59,7 @@ class ShipmentAdapter {
 			'company'    => $this->shipmentData['sender_company'],
 			'street'     => $this->shipmentData['sender_street'],
 			'street_no'  => $this->shipmentData['sender_street_no'] ?: $this->shipmentData['sender_street_nr'],
-			'care_of'    => $this->shipmentData['sender_care_of'],
+			'care_of'    => array_key_exists( 'sender_care_of', $this->shipmentData ) ? $this->shipmentData['sender_care_of'] : '',
 			'zip_code'   => $this->shipmentData['sender_zip_code'],
 			'city'       => $this->shipmentData['sender_city'],
 			'state'      => $this->shipmentData['sender_state'],

--- a/readme.txt
+++ b/readme.txt
@@ -115,6 +115,14 @@ https://youtu.be/HE3jow15x8c
 
 == Changelog ==
 
+= 1.6.4 =
+* Enhanced: Rework handling of WP_Error when deleting a shipment
+* Enhanced: Added method to shipment model so we can output error messages to the UI
+* Fixed: Standard carrier caused problems in checkout when buyer was selecting the shipping carrier.
+* Fixed: Added handling of undefined parcel, sender and shipment data
+* Fixed: Added backwards compatibility for getting the payment method (to check for cash on delivery)
+* Removed: Standard carrier from settings.
+
 = 1.6.3 =
 * Enhanced: Removed buttons for creating/preparing return shipments, because you can select returns as a service
 * Enhanced: Make it possible to supply a reference_number before creating a shipment

--- a/woocommerce-shipcloud-functions.php
+++ b/woocommerce-shipcloud-functions.php
@@ -513,18 +513,19 @@ function _wcsc_add_order_shipment( $order_id, $shipment, $data, $parcel_title = 
 		$shipment_data['recipient_street_no'] = $data['from']['street_nr'];
 	}
 
-	if ( isset( $data['from'] ) ) {
-		$shipment_data['sender_first_name'] = $data['from']['first_name'];
-		$shipment_data['sender_last_name']  = $data['from']['last_name'];
-		$shipment_data['sender_company']    = $data['from']['company'];
-		$shipment_data['sender_care_of']    = $data['from']['care_of'];
-		$shipment_data['sender_street']     = $data['from']['street'];
-		$shipment_data['sender_street_no']  = $data['from']['street_no'];
-		$shipment_data['sender_zip_code']   = $data['from']['zip_code'];
-		$shipment_data['sender_city']       = $data['from']['city'];
-		$shipment_data['sender_state']      = $data['from']['state'];
-		$shipment_data['sender_phone']      = $data['from']['phone'];
-		$shipment_data['country']           = $data['from']['country'];
+	$from = $data['from'];
+	if ( isset( $from ) ) {
+		$shipment_data['sender_first_name'] = $from['first_name'];
+		$shipment_data['sender_last_name']  = $from['last_name'];
+		$shipment_data['sender_company']    = array_key_exists('company', $from) ? $from['company'] : '';
+		$shipment_data['sender_care_of']    = array_key_exists('care_of', $from) ? $from['care_of'] : '';
+		$shipment_data['sender_street']     = $from['street'] ?: '';
+		$shipment_data['sender_street_no']  = $from['street_no'] ?: '';
+		$shipment_data['sender_zip_code']   = $from['zip_code'] ?: '';
+		$shipment_data['sender_city']       = $from['city'] ?: '';
+		$shipment_data['sender_state']      = array_key_exists('state', $from) ? $from['state'] : '';
+		$shipment_data['sender_phone']      = array_key_exists('phone', $from) ? $from['phone'] : '';
+		$shipment_data['country']           = $from['country'] ?: '';
 
 		// Fallback until v2.0.0
 		if ( isset( $data['to']['street_nr'] ) ) {


### PR DESCRIPTION
We needed to make a few adjustments to backwards compatible with WooCommerce 2, because users were getting warnings. Methods are now called by either going the WC3 or WC2 way. We've also made a few adjustments to the latest UI changes (for WC3) and ironed out some bugs.

The standard carrier config was removed, because due to the new way of handling parcel templates, it didn't make sense to use it anymore.

What has changed?
- added method `printErrors` to shipment model This way we can output error messages to the UI
- backwards compatibility for getting the payment method as well as the currency
- reworked handling of WP_Error when deleting a shipment. This also makes the error log messages translatable
- make plugin more robust by checking for indexes before accessing array elements
- removed the standard carrier config
- some CSS adjustments, because WC3 now display other data on the orders overview page
- only return allowed carriers if customer selects shipping method

## Things to review

Common things:

- [ ] Works fine.
- [ ] Changelog written or not needed.
- [ ] No conflict with current branch.
