### PR TITLE
add cod for gls and ups

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 == Changelog ==
 
+= 1.7.0 =
+- Enhanced: Carrier specific handling of cash on delivery attributes when using GLS or UPS as carrier
+
 = 1.6.6 =
 * Fixed: Creating return shipping labels.
 

--- a/components/woo/order.php
+++ b/components/woo/order.php
@@ -919,19 +919,19 @@ class WC_Shipcloud_Order
 	}
 
 	/**
-     * Get bank information for shop owner.
-     *
-     * @since 1.5.0
-     *
+	 * Get bank information for shop owner.
+	 *
+	 * @since 1.5.0
+	 *
 	 * @return \Shipcloud\Domain\ValueObject\BankInformation
 	 */
 	public function get_bank_information() {
-        return new \Shipcloud\Domain\ValueObject\BankInformation(
-            $this->get_options('bank_name'),
-            $this->get_options('bank_code'),
-            $this->get_options('bank_account_holder'),
-            $this->get_options('bank_account_number')
-        );
+		return new \Shipcloud\Domain\ValueObject\BankInformation(
+			$this->get_options('bank_name'),
+			$this->get_options('bank_code'),
+			$this->get_options('bank_account_holder'),
+			$this->get_options('bank_account_number')
+		);
 	}
 
 	/**
@@ -975,12 +975,13 @@ class WC_Shipcloud_Order
 		$data = $this->handle_email_notification( $data );
 
 		if ( 'returns' !== $data['service'] && wcsc_get_cod_id() === $this->__get('payment_method') ) {
-		    $cash_on_delivery = new \Shipcloud\Domain\Services\CashOnDelivery(
-                $order->get_total(),
-                $this->__get('currency'),
-                $this->get_bank_information(),
-                sprintf( __( 'WooCommerce OrderID: %s', 'shipcloud-for-woocommerce' ), $order_id )
-            );
+			$cash_on_delivery = new \Shipcloud\Domain\Services\CashOnDelivery(
+				$data['carrier'],
+				$order->get_total(),
+				$this->__get('currency'),
+				$this->get_bank_information(),
+				sprintf( __( 'WooCommerce OrderID: %s', 'shipcloud-for-woocommerce' ), $order_id )
+			);
 
 		    if (!isset($data['additional_services'])) {
 		        $data['additional_services'] = array();

--- a/includes/shipcloud/domain/services/cashondelivery.php
+++ b/includes/shipcloud/domain/services/cashondelivery.php
@@ -45,7 +45,7 @@ class CashOnDelivery {
 	 * @throws \InvalidArgumentException For invalid currencies
 	 * @throws \OutOfRangeException When the amount is out of allowed range.
 	 */
-	public function __construct( $amount, $currency, BankInformation $bankInformation, $reference = '' ) {
+	public function __construct( $carrier, $amount, $currency, BankInformation $bankInformation = null, $reference = null ) {
 		if ( $amount < 0.01 || $amount > 3500.00 ) {
 			throw new \OutOfRangeException( 'Invalid amount. Supported range is 0.01 - 3500.00' );
 		}
@@ -58,8 +58,12 @@ class CashOnDelivery {
 
 		$this->currency = $currency;
 
-		$this->bankInformation = $bankInformation;
-		$this->reference       = $reference;
+		if( $carrier !== 'ups' && $carrier !== 'gls' ) {
+			$this->reference = $reference;
+			$this->bankInformation = $bankInformation;
+		} elseif( $carrier === 'gls' ) {
+			$this->reference = $reference;
+		}
 	}
 
 	/**
@@ -91,14 +95,18 @@ class CashOnDelivery {
 	}
 
 	public function toArray() {
-		return array(
+		$cod_data = array(
 			'amount'              => $this->getAmount(),
 			'currency'            => $this->getCurrency(),
-			'bank_account_holder' => $this->getBankInformation()->getAccountHolder(),
-			'bank_name'           => $this->getBankInformation()->getBankName(),
-			'bank_account_number' => $this->getBankInformation()->getIban(),
-			'bank_code'           => $this->getBankInformation()->getBankSwift(),
 			'reference1'          => $this->getReference()
 		);
+		if(null !== $this->getBankInformation()) {
+			$cod_data['bank_account_holder'] = $this->getBankInformation()->getAccountHolder();
+			$cod_data['bank_name']           = $this->getBankInformation()->getBankName();
+			$cod_data['bank_account_number'] = $this->getBankInformation()->getIban();
+			$cod_data['bank_code']           = $this->getBankInformation()->getBankSwift();
+		}
+
+		return array_filter($cod_data);
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -115,6 +115,9 @@ https://youtu.be/HE3jow15x8c
 
 == Changelog ==
 
+= 1.7.0 =
+- Enhanced: Carrier specific handling of cash on delivery attributes when using GLS or UPS as carrier
+
 = 1.6.6 =
 * Fixed: Creating return shipping labels.
 


### PR DESCRIPTION
I've added additional handling for CoD when using GLS or UPS, since shipcloud only needs `amount` and `currency` when [using UPS](https://developers.shipcloud.io/examples/#ups---cash-on-delivery) and `amount`, `currency` and `reference1` when [using GLS](https://developers.shipcloud.io/examples/#gls---cash-on-delivery) with cash on delivery.


## Things to review

- [ ] Works fine.
- [ ] Changelog written or not needed.
- [ ] No conflict with current branch.

