### PR TITLE
use calculated weight for shipments

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.7.0 =
 * Added: WooCommerce version check headers
+* Added: Total order weight can now be used when creating shipments by selecting a checkbox
 * Enhanced: Carrier specific handling of cash on delivery attributes when using GLS or UPS as carrier
 * Enhanced: Service and package type are now preselected in dropdowns when selecting a new carrier
 

--- a/components/block/label-form.php
+++ b/components/block/label-form.php
@@ -26,7 +26,17 @@
         <th><?php _e( 'Weight', 'shipcloud-for-woocommerce' ); ?></th>
         <td>
             <input type="text" name="parcel_weight"
-                   class="lengths"/> <?php _e( 'kg', 'shipcloud-for-woocommerce' ); ?>
+                   class="lengths" />
+                   <?php _e( 'kg', 'shipcloud-for-woocommerce' ); ?>
+            <input type="checkbox" name="shipcloud_use_calculated_weight" value="use_calculated_weight" />
+            <?php
+              $wc_order = $this->get_order()->get_wc_order();
+              if( method_exists( $wc_order, 'get_order_number' ) ){
+                _e( sprintf('use calculated weight (%s)', $this->get_calculated_weight()), 'shipcloud-for-woocommerce' );
+              } else {
+                _e( sprintf('use calculated weight', 'shipcloud-for-woocommerce' ));
+              }
+            ?>
         </td>
     </tr>
     <tr>

--- a/components/woo/order-bulk.php
+++ b/components/woo/order-bulk.php
@@ -350,18 +350,22 @@ class WC_Shipcloud_Order_Bulk {
 			$order->get_wc_order()->get_order_number()
 		);
 
-		$addresses = $this->handle_return_shipments($order, $request);
-		
+		$use_calculated_weight = $request['shipcloud_use_calculated_weight'];
+		if ( $use_calculated_weight == 'use_calculated_weight' ) {
+			$request['parcel_weight'] = $order->get_calculated_weight();
+		}
+		$package = new \Shipcloud\Domain\Package(
+			wc_format_decimal( $request['parcel_length'] ),
+			wc_format_decimal( $request['parcel_width'] ),
+			wc_format_decimal( $request['parcel_height'] ),
+			wc_format_decimal( $request['parcel_weight'] ),
+			$request['shipcloud_carrier_package']
+		);
+
 		$data = array(
-			'from'                  => $addresses['from'],
-			'to'                    => $addresses['to'],
-			'package'               => new \Shipcloud\Domain\Package(
-				wc_format_decimal( $request['parcel_length'] ),
-				wc_format_decimal( $request['parcel_width'] ),
-				wc_format_decimal( $request['parcel_height'] ),
-				wc_format_decimal( $request['parcel_weight'] ),
-				$request['shipcloud_carrier_package']
-			),
+			'to'                    => $order->get_recipient(),
+			'from'                  => $order->get_sender(),
+			'package'               => $package,
 			'carrier'               => $request['shipcloud_carrier'],
 			'service'               => $request['shipcloud_carrier_service'],
 			'reference_number'      => $reference_number,

--- a/components/woo/order.php
+++ b/components/woo/order.php
@@ -540,7 +540,7 @@ class WC_Shipcloud_Order
 	{
 		ob_start();
 		?>
-		<div class="section parcels">
+		<div class="section parcels" data-calculated-weight="<?php echo( $this->get_calculated_weight() ); ?>" />
 			<h3><?php _e( 'Create shipment', 'shipcloud-for-woocommerce' ); ?></h3>
 
 			<?php echo $this->parcel_form(); ?>
@@ -1729,6 +1729,16 @@ class WC_Shipcloud_Order
 		}
 
 		return $data;
+	}
+	
+	public function get_calculated_weight() {
+		$order_items = $this->get_wc_order()->get_items();
+
+		$calculated_weight = 0;
+		foreach ( $order_items as $order_item ) {
+			$calculated_weight += $order_item->get_product()->get_weight();
+		}
+		return $calculated_weight;
 	}
 }
 

--- a/includes/js/shipcloud-label-form.js
+++ b/includes/js/shipcloud-label-form.js
@@ -42,11 +42,18 @@ shipcloud.LabelForm = function (wrapperSelector) {
     };
 
     this.getPackage = function () {
+      var use_calculated_weight = $('input[name="shipcloud_use_calculated_weight"]', self.$wrapper);
+      if (use_calculated_weight.prop('checked')) {
+        var weight = $('#shipment-center .section.parcels').data('calculated-weight');
+      } else {
+        var weight = $('input[name="parcel_weight"]', self.$wrapper).val();
+      }
+      
       var package_hash = {
         'width'      : $('input[name="parcel_width"]', self.$wrapper).val(),
         'height'     : $('input[name="parcel_height"]', self.$wrapper).val(),
         'length'     : $('input[name="parcel_length"]', self.$wrapper).val(),
-        'weight'     : $('input[name="parcel_weight"]', self.$wrapper).val(),
+        'weight'     : weight,
         'description': $('input[name="parcel_description"]', self.$wrapper).val(),
         'type'       : $('select[name="shipcloud_carrier_package"]', self.$wrapper).val()
       };

--- a/includes/shipcloud/block-labels-form.php
+++ b/includes/shipcloud/block-labels-form.php
@@ -105,6 +105,15 @@ class WooCommerce_Shipcloud_Block_Labels_Form {
 	public function dispatch() {
 		require $this->get_template_file();
 	}
+	
+	public function get_calculated_weight() {
+		$order_items = $this->get_order()->get_wc_order()->get_items();
+		$calculated_weight = 0;
+		foreach ( $order_items as $order_item ) {
+			$calculated_weight += $order_item->get_product()->get_weight();
+		}
+		return $calculated_weight;
+	}
 
 	/**
 	 * @return mixed

--- a/readme.txt
+++ b/readme.txt
@@ -117,6 +117,7 @@ https://youtu.be/HE3jow15x8c
 
 = 1.7.0 =
 * Added: WooCommerce version check headers
+* Added: Total order weight can now be used when creating shipments by selecting a checkbox
 * Enhanced: Carrier specific handling of cash on delivery attributes when using GLS or UPS as carrier
 * Enhanced: Service and package type are now preselected in dropdowns when selecting a new carrier
 


### PR DESCRIPTION
Instead of having to use the weight from a parcel template (which might be higher/lower) you can now select a checkbox and make sure that the calculated weight of all products is being used for creating the shipping label.

## Things to review

- [ ] Works fine.
- [ ] Changelog written or not needed.
- [ ] No conflict with current branch.

Fixes #100 
