### PR TITLE
added WooCommerce version check headers

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,8 @@
 == Changelog ==
 
 = 1.7.0 =
-- Enhanced: Carrier specific handling of cash on delivery attributes when using GLS or UPS as carrier
+* Added: WooCommerce version check headers
+* Enhanced: Carrier specific handling of cash on delivery attributes when using GLS or UPS as carrier
 
 = 1.6.6 =
 * Fixed: Creating return shipping labels.

--- a/readme.txt
+++ b/readme.txt
@@ -116,7 +116,8 @@ https://youtu.be/HE3jow15x8c
 == Changelog ==
 
 = 1.7.0 =
-- Enhanced: Carrier specific handling of cash on delivery attributes when using GLS or UPS as carrier
+* Added: WooCommerce version check headers
+* Enhanced: Carrier specific handling of cash on delivery attributes when using GLS or UPS as carrier
 
 = 1.6.6 =
 * Fixed: Creating return shipping labels.

--- a/woocommerce-shipcloud.php
+++ b/woocommerce-shipcloud.php
@@ -21,6 +21,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ * WC requires at least: 2.6.4
+ * WC tested up to: 3.3.3
  */
 
 /**


### PR DESCRIPTION
We're adding the [WooCommerce version check headers](https://woocommerce.wordpress.com/2017/08/28/new-version-check-in-woocommerce-3-2/) to make it easier for customers to know if they can use the plugin with a specific WooCommerce version

## Things to review

- [ ] Works fine.
- [ ] Changelog written or not needed.
- [ ] No conflict with current branch.

Fixes #174 