### PR TITLE
select first option from dropdowns when selecting carrier

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 1.7.0 =
 * Added: WooCommerce version check headers
 * Enhanced: Carrier specific handling of cash on delivery attributes when using GLS or UPS as carrier
+* Enhanced: Service and package type are now preselected in dropdowns when selecting a new carrier
 
 = 1.6.6 =
 * Fixed: Creating return shipping labels.

--- a/includes/js/multi-select.js
+++ b/includes/js/multi-select.js
@@ -62,9 +62,15 @@ shipcloud.MultiSelect = function (wrapperSelector, options) {
                 return;
             }
 
-            selectNode.append(
+            if(index == 0) {
+              selectNode.append(
+                '<option value="' + value + '" selected="selected">' + self.options.label[type][value] + '</option>'
+              );
+            } else {
+              selectNode.append(
                 '<option value="' + value + '">' + self.options.label[type][value] + '</option>'
-            );
+              );
+            }
         });
 
         selectNode.prop('disabled', null);

--- a/readme.txt
+++ b/readme.txt
@@ -118,6 +118,7 @@ https://youtu.be/HE3jow15x8c
 = 1.7.0 =
 * Added: WooCommerce version check headers
 * Enhanced: Carrier specific handling of cash on delivery attributes when using GLS or UPS as carrier
+* Enhanced: Service and package type are now preselected in dropdowns when selecting a new carrier
 
 = 1.6.6 =
 * Fixed: Creating return shipping labels.


### PR DESCRIPTION
When loading the page or changing the carrier, the first option in the services and package type dropdowns now gets preselected. This way the customer doesn't have to make 2 unnecessary clicks.

## Things to review

- [ ] Works fine.
- [ ] Changelog written or not needed.
- [ ] No conflict with current branch.

Fixes #107 