### PR TITLE
configure check before label creation

### DIFF
--- a/components/woo/order.php
+++ b/components/woo/order.php
@@ -558,7 +558,7 @@ class WC_Shipcloud_Order
 					</button>
 				</p>
 				<p>
-					<button id="shipcloud_create_shipment_label" type="button" value="<?php _e( 'Create label', 'shipcloud-for-woocommerce' ); ?>" class="button-primary">
+					<button id="shipcloud_create_shipment_label" type="button" value="<?php _e( 'Create label', 'shipcloud-for-woocommerce' ); ?>" class="button-primary" data-ask-create-label-check="<?php echo esc_attr($this->get_options( 'ask_create_label_check' )); ?>">
 						<?php _e( 'Create label', 'shipcloud-for-woocommerce' ); ?>
 					</button>
 				</p>

--- a/components/woo/shipping-method.php
+++ b/components/woo/shipping-method.php
@@ -537,6 +537,12 @@ class WC_Shipcloud_Shipping extends WC_Shipping_Method
 				'label'   => __( 'Automatic split street from street number (in some countries this do not work correct because of different street number schemes).', 'shipcloud-for-woocommerce' ),
 				'default' => 'yes'
 			),
+			'ask_create_label_check' => array(
+				'title'   => __( 'Ask before creating a shipping label', 'shipcloud-for-woocommerce' ),
+				'type'    => 'checkbox',
+				'label'   => __( 'Safety check that adds a dialog to ask you if you really want to create a shipping label', 'shipcloud-for-woocommerce' ),
+				'default' => 'yes'
+			),
 		);
 
 		$this->instance_form_fields = array(

--- a/includes/js/admin.js
+++ b/includes/js/admin.js
@@ -111,35 +111,41 @@ jQuery( function( $ ) {
 		$( '#shipment-center .info').empty();
 		var data = get_shipment_form_data( 'shipcloud_create_shipment_label', false );
 
-		var ask_create_label = $('#ask-create-label');
-
 		var self = this;
+		
+		var should_ask = $(this).data('ask-create-label-check');
+		
+		if( 'yes' == should_ask) {
+			var ask_create_label = $('#ask-create-label');
 
-		ask_create_label.dialog({
-			'dialogClass': 'wcsc-dialog wp-dialog',
-			'modal': true,
-			'autoOpen': false,
-			'closeOnEscape': true,
-			'minHeight': 80,
-			'buttons': [{
-				text: wcsc_translate.yes,
-				click: function () {
-					shipcloud_create_shipment_label(data, self);
-
-					$(this).dialog("close");
-				}
-			},
-				{
-					text: wcsc_translate.no,
+			ask_create_label.dialog({
+				'dialogClass': 'wcsc-dialog wp-dialog',
+				'modal': true,
+				'autoOpen': false,
+				'closeOnEscape': true,
+				'minHeight': 80,
+				'buttons': [{
+					text: wcsc_translate.yes,
 					click: function () {
+						shipcloud_create_shipment_label(data, self);
+
 						$(this).dialog("close");
 					}
 				},
-			],
+					{
+						text: wcsc_translate.no,
+						click: function () {
+							$(this).dialog("close");
+						}
+					},
+				],
 
-		});
+			});
 
-		ask_create_label.dialog("open");
+			ask_create_label.dialog("open");
+		} else {
+			shipcloud_create_shipment_label(data, self);
+		}
 	});
 
 	function shipcloud_delete_shipment_buttons() {


### PR DESCRIPTION
add config for enabling/disabling the check dialog before creating a shipping label

This way the admin can decide to enable or disable the check globally. It's on per default to make sure the admin get's asked and because it's the current behaviour


## Things to review

- [ ] Works fine.
- [ ] Changelog written or not needed.
- [ ] No conflict with current branch.