### PR TITLE
add pickup requests

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,11 +1,13 @@
 == Changelog ==
 
 = 1.9.0 =
+* Enhanced: Added possibility to create pickup requests (only in WooCommerce 3)
 * Enhanced: Make it possible to define a global key to be used as reference number. Introduced shortcodes to make the key customizable
 * Enhanced: Added configuration for displaying the pakadoo id within checkout (billing address)
 * Enhanced: Added configuration for displaying a care of field within checkout (billing & shipping address)
 * Enhanced: Added configuration for displaying a phone field within checkout (billing address)
 * Fixed: Use official language for shipments with advance notice
+* Fixed: Link carrier tracking number to carrier tracking page
 
 = 1.8.2 =
 * Enhanced: Show info at api url page if called via get-request

--- a/components/block/bulk-action-template.php
+++ b/components/block/bulk-action-template.php
@@ -1,0 +1,5 @@
+<script type="template/html" id="tmpl-shipcloud-bulk-action-items">
+    <div data-id="{{ data.id }}">
+        {{ data.title }}
+    </div>
+</script>

--- a/components/block/label-form.php
+++ b/components/block/label-form.php
@@ -57,7 +57,13 @@
         </td>
     </tr>
     <tr>
-        <th><?php _e( 'Shipping method', 'shipcloud-for-woocommerce' ); ?></th>
+        <th>
+            <?php _e( 'Shipping method', 'shipcloud-for-woocommerce' ); ?>
+            <?php if ( $this->get_shipping_method_name() ): ?>
+                <br />
+                <small><?php echo sprintf( __( 'Ordered: %s', 'shipcloud-for-woocommerce' ), $this->get_shipping_method_name() ); ?></small>
+            <?php endif; ?>
+        </th>
         <td>
 			<?php if ( count( $this->get_allowed_carriers() ) > 0 ): ?>
                 <div id="shipcloud_csp_wrapper" class="shipcloud-carrier-select">
@@ -77,12 +83,12 @@
 					admin_url( 'admin.php?page=wc-settings&tab=shipping&section=wc_shipcloud_shipping' )
 				); ?>
 			<?php endif; ?>
-
-			<?php if ( $this->get_shipping_method_name() ): ?>
-                <br/>
-                <small><?php echo sprintf( __( 'Ordered: %s', 'shipcloud-for-woocommerce' ), $this->get_shipping_method_name() ); ?></small>
-			<?php endif; ?>
-
+        </td>
+    </tr>
+    <tr>
+        <th><?php _e( 'Shipment description', 'shipcloud-for-woocommerce' ); ?></th>
+        <td>
+            <input type="text" name="other_description" value="<?php echo esc_attr($this->get_order()->get_description()); ?>">
         </td>
     </tr>
     <?php
@@ -120,9 +126,15 @@
                 <input type="text"
                        name="parcel_description"
                        value="<?php echo esc_attr( wcsc_order_get_parcel_description( $this->get_order()->get_wc_order() ) ) ?>"/>
-                <small><?php echo sprintf( __( 'Required for carriers: %s', 'shipcloud-for-woocommerce' ), 'DPD' ); ?></small>
             </td>
         </tr>
-	<?php endif; ?>
+    <?php
+        endif;
+
+        // only applicable for WooCommerce 3
+        if (class_exists('WC_DateTime')) {
+            require WCSC_COMPONENTFOLDER . '/block/pickup-date-and-time.php';
+        }
+    ?>
     </tbody>
 </table>

--- a/components/block/order-label-template.php
+++ b/components/block/order-label-template.php
@@ -178,7 +178,7 @@
                         <th><?php _e( 'Tracking number:', 'shipcloud-for-woocommerce' ); ?></th>
                         <td class="tracking-number">
                             <# if ( data.model.get('carrier_tracking_no') ) { #>
-                                <a href="{{ data.model.get('carrier_tracking_url') }}" target="_blank">
+                                <a href="{{ data.model.getCarrierTrackingUrl() }}" target="_blank">
                                   {{ data.model.get('carrier_tracking_no') }}
                                 </a>
                             <# } else { #>
@@ -210,42 +210,65 @@
             </tbody>
         </table>
 
+        <div class="label-shipment-pickup-request">
+            <# if ( data.model.get('pickup_request') ) { #>
+                <strong><?php _e( 'Pickup timeframe', 'shipcloud-for-woocommerce' ); ?></strong>
+                <div>
+                    {{ data.model.get('pickup_request').getPickupTimeAsRange() }}
+                </div>
+                <# if ( data.model.get('pickup_request').get('pickup_address') ) { #>
+                    <br />
+                    <strong><?php _e( 'Pickup address', 'shipcloud-for-woocommerce' ); ?></strong>
+                    <div>{{ data.model.get('pickup_request').get('pickup_address').get('company') }}</div>
+                    <div>{{ data.model.get('pickup_request').get('pickup_address').getFullName() }}</div>
+                    <div>{{ data.model.get('pickup_request').get('pickup_address').getFullStreet() }}</div>
+                    <div>{{ data.model.get('pickup_request').get('pickup_address').get('care_of') }}</div>
+                    <div>{{ data.model.get('pickup_request').get('pickup_address').getFullCity() }}</div>
+                    <div>{{ data.model.get('pickup_request').get('pickup_address').get('state') }}</div>
+                    <div>{{ data.model.get('pickup_request').get('pickup_address').get('country') }}</div>
+                <# } #>
+            <# } #>
+        </div>
+
         <div class="label-shipment-actions">
+            <button type="button" class="shipcloud_delete_shipment button">
+                <?php _e( 'Delete shipment', 'shipcloud-for-woocommerce' ); ?>
+            </button>
+
             <# if ( data.model.get('label_url') ) { #>
                 <a href="{{ data.model.get('label_url') }}" target="_blank" class="button">
-					<?php _e( 'Download label', 'shipcloud-for-woocommerce' ); ?>
+                    <?php _e( 'Download label', 'shipcloud-for-woocommerce' ); ?>
                 </a>
-                <# } else { #>
-                    <button class="shipcloud_create_label button-primary" type="button">
-						<?php _e( 'Create label', 'shipcloud-for-woocommerce' ); ?>
+
+        <?php
+            // only applicable for WooCommerce 3
+            if (class_exists('WC_DateTime')) :
+        ?>
+                <# if ( !data.model.get('pickup_request') ) { #>
+                    <button class="button button-primary shipcloud-open-pickup-request-form" role="switch" type="button">
+                        <?php _e( 'Create pickup request', 'shipcloud-for-woocommerce' ) ?>
                     </button>
                 <# } #>
-
-                <# if ( data.model.get('tracking_url') ) { #>
-                <a href="{{ data.model.getCarrierTrackingUrl() }}" target="_blank" class="button">
-                    <?php _e( 'Tracking link', 'shipcloud-for-woocommerce' ); ?>
-                </a>
-                <# } #>
-
-                <button class="button wcsc-save-shipment button-primary" role="switch" type="button"
-                        style="display: none;">
-                    <?php _ex( 'Save', 'Order: Backend button to edit prepared labels', 'wcsc' ) ?>
-                </button>
-
-                <# if ( ! data.model.get('label_url') ) { #>
+        <?php endif; ?>
+            <# } else { #>
                 <button class="button wcsc-edit-shipment" role="switch" type="button">
                     <?php _ex( 'Edit shipment', 'Order: Backend button to edit prepared labels', 'wcsc' ) ?>
                 </button>
-                <# } #>
 
-                <button type="button" class="shipcloud_delete_shipment button">
-                    <?php _e( 'Delete shipment', 'shipcloud-for-woocommerce' ); ?>
+                <button class="shipcloud_create_label button-primary" type="button">
+                    <?php _e( 'Create label', 'shipcloud-for-woocommerce' ); ?>
                 </button>
+            <# } #>
 
-                <input type="hidden" name="carrier" value="{{ data.model.get('carrier') }}"/>
-                <input type="hidden" name="service" value="{{ data.model.get('service') }}"/>
-                <input type="hidden" name="shipment_id" value="{{ data.model.get('id') }}"/>
-                <input type="hidden" name="shipment_order_id" value="<?php echo get_the_ID(); ?>"/>
+            <button class="button wcsc-save-shipment button-primary" role="switch" type="button"
+                    style="display: none;">
+                <?php _ex( 'Save', 'Order: Backend button to edit prepared labels', 'wcsc' ) ?>
+            </button>
+
+            <input type="hidden" name="carrier" value="{{ data.model.get('carrier') }}"/>
+            <input type="hidden" name="service" value="{{ data.model.get('service') }}"/>
+            <input type="hidden" name="shipment_id" value="{{ data.model.get('id') }}"/>
+            <input type="hidden" name="shipment_order_id" value="<?php echo get_the_ID(); ?>"/>
         </div>
 
     </div>

--- a/components/block/order-labels-bulk.php
+++ b/components/block/order-labels-bulk.php
@@ -13,7 +13,7 @@
                 </legend>
                 <div class="inline-edit-col">
                     <div class="bulk-title-div">
-                        <div class="bulk-titles"></div>
+                        <div class="order-id-list"></div>
                     </div>
                 </div>
             </fieldset>
@@ -81,11 +81,4 @@
         $('#shipcloud_bulk').find('#shipcloud_csp_wrapper').shipcloudMultiSelect(wcsc_carrier);
         $('select[name="parcel_list"]').shipcloudFiller('table.parcel-form-table');
     });
-</script>
-
-<script type="template/html" id="tmpl-wcsc-order-labels-bulk-items">
-    <div data-id="{{ data.id }}"
-         class="bulk-title">
-        {{ data.title }}
-    </div>
 </script>

--- a/components/block/order-shipment-edit.php
+++ b/components/block/order-shipment-edit.php
@@ -159,6 +159,14 @@
    ?>
 </fieldset>
 
+<# if ( data.model.get('pickup_request') ) { #>
+    <fieldset class="label-shipment-pickup-request">
+      <?php
+        require WCSC_COMPONENTFOLDER . '/block/pickup-date-and-time-edit-form.php';
+       ?>
+    </fieldset>
+<# } #>
+
 <input type="hidden" name="shipment[package][weight]" value="{{ data.model.get('package').get('width') }}" />
 <input type="hidden" name="shipment[package][length]" value="{{ data.model.get('package').get('length') }}" />
 <input type="hidden" name="shipment[package][width]" value="{{ data.model.get('package').get('width') }}" />

--- a/components/block/pickup-date-and-time-edit-form.php
+++ b/components/block/pickup-date-and-time-edit-form.php
@@ -1,0 +1,21 @@
+<h4><?php _e( 'Pickup date and time', 'shipcloud-for-woocommerce' ); ?></h4>
+<div class="shipcloud__pickup_time">
+    <div class="shipcloud__pickup_time--earliest">
+        <label for="pickup_earliest_date">
+            <small><?php _e( 'Earliest pickup date and time', 'shipcloud-for-woocommerce' ) ?></small>
+        </label>
+        <input type="text" class="date-picker pickup_date" name="pickup_earliest_date" maxlength="10" pattern="<?php echo esc_attr( apply_filters( 'woocommerce_date_input_html_pattern', '[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|1[0-9]|2[0-9]|3[01])' ) ); ?>" value="{{ data.model.get('pickup_request').getPickupTimeAsHash('earliest').date }}" />@
+        &lrm;
+        <input type="number" class="pickup_time hour" placeholder="<?php esc_attr_e( 'h', 'woocommerce' ) ?>" name="pickup_earliest_time_hour" min="0" max="23" step="1" pattern="([01]?[0-9]{1}|2[0-3]{1})" value="{{ data.model.get('pickup_request').getPickupTimeAsHash('earliest').hours }}" />:
+        <input type="number" class="pickup_time minute" placeholder="<?php esc_attr_e( 'm', 'woocommerce' ) ?>" name="pickup_earliest_time_minute" min="0" max="59" step="1" pattern="[0-5]{1}[0-9]{1}" value="{{ data.model.get('pickup_request').getPickupTimeAsHash('earliest').minutes }}" />
+    </div>
+    <div class="shipcloud__pickup_time--latest">
+        <label for="pickup_latest_date">
+            <small><?php _e( 'Latest pickup date and time', 'shipcloud-for-woocommerce' ) ?></small>
+        </label>
+        <input type="text" class="date-picker pickup_date" name="pickup_latest_date" maxlength="10" pattern="<?php echo esc_attr( apply_filters( 'woocommerce_date_input_html_pattern', '[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|1[0-9]|2[0-9]|3[01])' ) ); ?>" value="{{ data.model.get('pickup_request').getPickupTimeAsHash().date }}" />@
+        &lrm;
+        <input type="number" class="pickup_time hour" placeholder="<?php esc_attr_e( 'h', 'woocommerce' ) ?>" name="pickup_latest_time_hour" min="0" max="23" step="1" pattern="([01]?[0-9]{1}|2[0-3]{1})" value="{{ data.model.get('pickup_request').getPickupTimeAsHash().hours }}" />:
+        <input type="number" class="pickup_time minute" placeholder="<?php esc_attr_e( 'm', 'woocommerce' ) ?>" name="pickup_latest_time_minute" min="0" max="59" step="1" pattern="[0-5]{1}[0-9]{1}" value="{{ data.model.get('pickup_request').getPickupTimeAsHash().minutes }}" />
+    </div>
+</div>

--- a/components/block/pickup-date-and-time.php
+++ b/components/block/pickup-date-and-time.php
@@ -1,0 +1,39 @@
+<tr class="shipcloud__pickup_date_and_time">
+    <th>
+        <?php _e( 'Pickup date and time', 'shipcloud-for-woocommerce' ); ?>
+        <?php echo wc_help_tip( __( 'If you\'re using an express carrier you might have to specify this', 'shipcloud-for-woocommerce' ) ); ?>
+    </th>
+    <td>
+        <div class="shipcloud__pickup_time">
+            <div class="shipcloud__pickup_time--earliest">
+                <div>
+                    <?php
+                        $today = new DateTime('NOW');
+                    ?>
+                    <input type="text" class="date-picker pickup_date" name="pickup_earliest_date" value="<?php echo esc_attr( date_i18n( 'Y-m-d', strtotime( $today->format('Y-m-d') ) ) ); ?>" maxlength="10" pattern="<?php echo esc_attr( apply_filters( 'woocommerce_date_input_html_pattern', '[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|1[0-9]|2[0-9]|3[01])' ) ); ?>" />@
+                    &lrm;
+                    <input type="number" class="pickup_time hour" placeholder="<?php esc_attr_e( 'h', 'woocommerce' ) ?>" name="pickup_earliest_time_hour" min="0" max="23" step="1" pattern="([01]?[0-9]{1}|2[0-3]{1})" />:
+                    <input type="number" class="pickup_time minute" placeholder="<?php esc_attr_e( 'm', 'woocommerce' ) ?>" name="pickup_earliest_time_minute" min="0" max="59" step="1" pattern="[0-5]{1}[0-9]{1}" />
+                </div>
+                <div>
+                    <label for="pickup_earliest_date">
+                        <small><?php _e( 'Earliest pickup date and time', 'shipcloud-for-woocommerce' ) ?></small>
+                    </label>
+                </div>
+            </div>
+            <div class="shipcloud__pickup_time--latest">
+                <div>
+                    <input type="text" class="date-picker pickup_date" name="pickup_latest_date" value="<?php echo esc_attr( date_i18n( 'Y-m-d', strtotime( $today->format('Y-m-d') ) ) ); ?>" maxlength="10" pattern="<?php echo esc_attr( apply_filters( 'woocommerce_date_input_html_pattern', '[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|1[0-9]|2[0-9]|3[01])' ) ); ?>" />@
+                    &lrm;
+                    <input type="number" class="pickup_time hour" placeholder="<?php esc_attr_e( 'h', 'woocommerce' ) ?>" name="pickup_latest_time_hour" min="0" max="23" step="1" pattern="([01]?[0-9]{1}|2[0-3]{1})" />:
+                    <input type="number" class="pickup_time minute" placeholder="<?php esc_attr_e( 'm', 'woocommerce' ) ?>" name="pickup_latest_time_minute" min="0" max="59" step="1" pattern="[0-5]{1}[0-9]{1}" />
+                </div>
+                <div>
+                    <label for="pickup_latest_date">
+                        <small><?php _e( 'Latest pickup date and time', 'shipcloud-for-woocommerce' ) ?></small>
+                    </label>
+                </div>
+            </div>
+        </div>
+    </td>
+</tr>

--- a/components/block/pickup-request-form-basic.php
+++ b/components/block/pickup-request-form-basic.php
@@ -1,0 +1,11 @@
+<?php
+    require WCSC_COMPONENTFOLDER . '/block/pickup-request-form-table.php';
+?>
+<div class="label-shipment-actions">
+    <button class="button shipcloud-pickup-request-abort" type="button">
+        <?php _e( 'Abort', 'shipcloud-for-woocommerce' ) ?>
+    </button>
+    <button class="button shipcloud-create-pickup-request button-primary" type="button">
+        <?php _e( 'Create pickup request', 'shipcloud-for-woocommerce' ) ?>
+    </button>
+</div>

--- a/components/block/pickup-request-form-table.php
+++ b/components/block/pickup-request-form-table.php
@@ -1,0 +1,77 @@
+<?php
+    global $woocommerce;
+?>
+
+<table class="shipcloud-pickup-request-form-table parcel-form-table">
+    <tbody>
+        <?php
+            require WCSC_COMPONENTFOLDER . '/block/pickup-date-and-time.php';
+        ?>
+        <tr>
+            <th colspan="2">
+                <a class="shipcloud-use-different-pickup-address">
+                    <?php _e( 'Use different pickup address', 'shipcloud-for-woocommerce' ); ?> &gt;&gt;
+                </a>
+            </th>
+        </tr>
+        <tr class="shipcloud-different-pickup-address">
+            <th>
+                <?php _e( 'Pickup address', 'shipcloud-for-woocommerce' ); ?>
+            </th>
+            <td>
+                <p class="form-field pickup_address_company_field">
+                    <input type="text" name="pickup_address[company]" value="">
+                    <label for="pickup_address[company]"><?php _e( 'Company', 'shipcloud-for-woocommerce' ); ?></label>
+                </p>
+                <p class="form-field pickup_address_first_name_field">
+                    <input type="text" name="pickup_address[first_name]" value="">
+                    <label for="pickup_address[first_name]"><?php _e( 'First name', 'shipcloud-for-woocommerce' ); ?></label>
+                </p>
+                <p class="form-field pickup_address_last_name_field">
+                    <input type="text" name="pickup_address[last_name]" value="">
+                    <label for="pickup_address[last_name]"><?php _e( 'Last name', 'shipcloud-for-woocommerce' ); ?></label>
+                </p>
+                <p class="form-field pickup_address_street_field">
+                    <input type="text" name="pickup_address[street]" value="">
+                    <label for="pickup_address[street]"><?php _e( 'Street', 'shipcloud-for-woocommerce' ); ?></label>
+                </p>
+                <p class="form-field pickup_address_number_field">
+                    <input type="text" name="pickup_address[street_no]" value="">
+                    <label for="pickup_address[street_no]"><?php _e( 'House number', 'shipcloud-for-woocommerce' ); ?></label>
+                </p>
+                <p class="form-field pickup_address_zip_code_field">
+                    <input type="text" name="pickup_address[zip_code]" value="">
+                    <label for="pickup_address[zip_code]"><?php _e( 'Zip code', 'shipcloud-for-woocommerce' ); ?></label>
+                </p>
+                <p class="form-field pickup_address_city_field">
+                    <input type="text" name="pickup_address[city]" value="">
+                    <label for="pickup_address[city]"><?php _e( 'City', 'shipcloud-for-woocommerce' ); ?></label>
+                </p>
+                <p class="form-field pickup_address_country_field">
+                    <select name="pickup_address[country]">
+                        <?php
+                            $base_country = $woocommerce->countries->get_base_country();
+
+                            foreach ( $woocommerce->countries->countries AS $key => $country ) {
+                                if ( $key === $base_country ) {
+                                    echo(sprintf('<option value="%s" selected>%s</option>', $key, $country));
+                                } else {
+                                    echo(sprintf('<option value="%s">%s</option>', $key, $country));
+                                }
+                            }
+                        ?>
+                    </select>
+                    <label for="pickup_address[country]"><?php _e( 'Country', 'shipcloud-for-woocommerce' ); ?></label>
+                </p>
+                <p class="form-field pickup_address_state_field">
+                    <input type="text" name="pickup_address[state]" value="">
+                    <label for="pickup_address[state]"><?php _e( 'State', 'shipcloud-for-woocommerce' ); ?></label>
+                </p>
+                <p class="form-field pickup_address_phone_field">
+                    <input type="text" name="pickup_address[phone]" value="">
+                    <label for="pickup_address[phone]"><?php _e( 'Phone', 'shipcloud-for-woocommerce' ); ?></label>
+                </p>
+            </td>
+        </tr>
+    </tbody>
+</table>

--- a/components/block/pickup-request-form.php
+++ b/components/block/pickup-request-form.php
@@ -1,0 +1,36 @@
+<table class="shipcloud-pickup-request-table" style="display: none;">
+    <tbody>
+        <tr
+            id="shipcloud-pickup-request"
+            class="inline-edit-row inline-edit-row-page inline-edit-shop_order bulk-edit-row bulk-edit-row-page bulk-edit-shop_order">
+            <td colspan="10" class="colspanchange" id="shipcloud-io">
+                <fieldset class="inline-edit-col-left">
+                    <legend class="inline-edit-legend">
+                        <?php esc_html_e( 'Create pickup request', 'shipcloud-for-woocommerce' ) ?>
+                    </legend>
+                    <div class="inline-edit-col">
+                        <div class="order-id-list"></div>
+                    </div>
+                </fieldset>
+                <fieldset class="inline-edit-col-right">
+                    <?php
+                        require WCSC_COMPONENTFOLDER . '/block/pickup-request-form-table.php';
+                    ?>
+                </fieldset>
+                <p class="submit inline-edit-save">
+                    <button type="button" class="button cancel alignleft">
+                        <?php esc_html_e( 'Cancel' ) ?>
+                    </button>
+                    <input type="submit"
+                           id="<?php esc_attr_e(WC_Shipcloud_Order_Bulk::BUTTON_PICKUP_REQUEST) ?>"
+                           name="<?php esc_attr_e(WC_Shipcloud_Order_Bulk::BUTTON_PICKUP_REQUEST) ?>"
+                           class="button button-primary alignright"
+                           value="<?php esc_attr_e( 'Create pickup request', 'woocommerce-shipcloud' ) ?>">
+                    <input type="hidden" name="screen" value="edit-<?php get_current_screen()->id ?>">
+                    <span class="error" style="display:none"></span>
+                    <br class="clear">
+                </p>
+            </td>
+        </tr>
+    </tbody>
+</table>

--- a/includes/css/admin.css
+++ b/includes/css/admin.css
@@ -117,7 +117,7 @@
     font-weight: normal;
     vertical-align: top;
     padding-top: 8px;
-    width: max-content;
+    width: 30%;
 }
 #shipcloud-io .parcel-form-table td{
     vertical-align: top;
@@ -128,6 +128,25 @@
 }
 #shipcloud-io .parcel-form-table input[type=text].lengths{
     width:50px;
+}
+#shipcloud-io .parcel-form-table .shipcloud__pickup_time--earliest,
+#shipcloud-io .parcel-form-table .shipcloud__pickup_time--latest {
+  display: inline-block;
+}
+#shipcloud-io .parcel-form-table .shipcloud__pickup_time--earliest {
+  margin-right: 15px;
+}
+#shipcloud-io .parcel-form-table .shipcloud__pickup_time--earliest label,
+#shipcloud-io .parcel-form-table .shipcloud__pickup_time--latest label {
+  width: 100%;
+}
+#shipcloud-io .parcel-form-table .shipcloud__pickup_time .pickup_date,
+#shipcloud-io .label-shipment-pickup-request .shipcloud__pickup_time .pickup_date {
+  width: 100px;
+}
+#shipcloud-io .parcel-form-table .shipcloud__pickup_time .pickup_time,
+#shipcloud-io .label-shipment-pickup-request .shipcloud__pickup_time .pickup_time {
+  width: 50px;
 }
 #shipcloud-io .parcel-template-field{
     margin-bottom:10px;
@@ -293,10 +312,12 @@
 
 #shipcloud-io .shipment-labels .address,
 #shipcloud-io .shipment-labels .label-shipment-additional-services,
+#shipcloud-io .shipment-labels .label-shipment-pickup-request,
+#shipcloud-io .shipment-labels .label-shipment-status,
 fieldset .shipment-labels .address {
     width: 31%;
     display: inline-block;
-    margin: 0 1%;
+    margin: 20px 1%;
     vertical-align: top;
 }
 
@@ -306,7 +327,7 @@ fieldset .shipment-labels .address {
 
 #shipcloud-io .label-shipment-actions{
     text-align: right;
-    width: 29%;
+    width: 100%;
     display: inline-block;
 }
 
@@ -474,4 +495,31 @@ fieldset .shipment-labels .address {
  */
 #shipcloud_bulk .parcel-form-table th {
   width: 25%;
+}
+
+.shipcloud-pickup-request-form-table .shipcloud-different-pickup-address {
+  display: none;
+}
+
+.shipcloud-pickup-request-form-table .shipcloud-different-pickup-address .form-field {
+  float: left;
+  clear: left;
+  width: 48%;
+}
+
+.shipcloud-pickup-request-form-table .shipcloud-different-pickup-address .form-field.pickup_address_last_name_field,
+.shipcloud-pickup-request-form-table .shipcloud-different-pickup-address .form-field.pickup_address_number_field,
+.shipcloud-pickup-request-form-table .shipcloud-different-pickup-address .form-field.pickup_address_city_field,
+.shipcloud-pickup-request-form-table .shipcloud-different-pickup-address .form-field.pickup_address_state_field {
+  float: right;
+  clear: right;
+}
+
+.shipcloud-pickup-request-form-table .shipcloud-different-pickup-address .form-field.pickup_address_company_field,
+.shipcloud-pickup-request-form-table .shipcloud-different-pickup-address .pickup_address_phone_field {
+  width: 100%;
+  clear: both
+}
+.shipcloud-pickup-request-form-table .shipcloud-different-pickup-address .form-field .select2-container {
+  width: 100%!important;
 }

--- a/includes/js/admin.js
+++ b/includes/js/admin.js
@@ -53,7 +53,11 @@ jQuery( function( $ ) {
         	return labelForm.getReturnLabelData();
 		}
 
-        return labelForm.getLabelData();
+        var labelData = labelForm.getLabelData()
+        labelData['pickup_earliest'] = labelForm.handlePickup('earliest');
+        labelData['pickup_latest'] = labelForm.handlePickup('latest');
+
+        return labelData;
 	};
 
 	$( '#shipcloud_calculate_price' ).click( function(){

--- a/includes/js/bulk-actions.js
+++ b/includes/js/bulk-actions.js
@@ -1,0 +1,158 @@
+;var wcsc = wcsc || {};
+
+wcsc.OrderBulkActions = function (submitButton) {
+  // jQuery and self reference as usual.
+  var $ = jQuery;
+  var self = this;
+
+  // Protected fields
+  this.bulkId = 'wcsc_order_bulk_label';
+  this.bulkScreen = '#wcsc-order-bulk-labels';
+  this.bulkActionTemplate = 'shipcloud-bulk-action-items';
+  this.$submitButton = $(submitButton);
+  this.pickupRequestId = 'shipcloud_create_pickup_request';
+  this.pickupRequestTemplateId = '#shipcloud-pickup-request';
+
+  this.main = function () {
+    self.$submitButton.click(self.handleSubmit);
+    $('#wcsc_template').change(self.handleTemplateSwitch);
+  };
+
+  this.handleSubmit = function (e) {
+    e.preventDefault();
+
+    if (!self.hasOrdersSelected()) {
+      return;
+    }
+
+    self.hideBulkActionTemplates();
+
+    var n = $(this).attr('id').substr(2);
+
+    var entryname = $('select[name="' + n + '"]').val();
+    switch (entryname) {
+      case self.bulkId:
+        self.setBulk();
+        break;
+      case self.pickupRequestId:
+        self.showPickupForm();
+        break;
+    }
+
+    return false;
+  };
+
+  this.handleTemplateSwitch = function () {
+    var data = $(':selected', this).data();
+
+    for (var key in data) {
+      $('input[name=wcsc_' + key + ']').val(data[key]);
+    }
+
+    if (data['carrier']) {
+      $('select[name=wcsc_carrier]').val(data['carrier']);
+    }
+  };
+
+  this.emptyTitles = function (templateId) {
+    $('.order-id-list', templateId).html('');
+    // switch (action) {
+    //   case 'label-creation':
+    //     $('.order-id-list', self.bulkScreen).html('');
+    //     break;
+    //   case 'pickup-request':
+    //     $('.order-id-list', self.pickupRequestTemplateId).html('');
+    //     break;
+    // }
+  };
+
+  this.hideBulkActionTemplates = function () {
+    $(self.bulkScreen).hide();
+    $(self.pickupRequestTemplateId).hide();
+  }
+
+  this.populateTitles = function (templateId) {
+    self.emptyTitles(templateId);
+
+    var template = wp.template(self.bulkActionTemplate);
+
+    $('tbody th.check-column input[type="checkbox"]').each(function () {
+      if (!$(this).prop('checked')) {
+        return;
+      }
+
+      var data = {
+        'id': $(this).val(),
+        'title': '#' + $(this).val()
+      };
+
+      $('.order-id-list', self.bulkScreen).append(template(data));
+    });
+  };
+
+  this.hasOrdersSelected = function () {
+    var ithasOrdersSelected = false;
+
+    $('tbody th.check-column input[type="checkbox"]').each(function () {
+      if ($(this).prop('checked')) {
+        ithasOrdersSelected = true;
+      }
+    });
+
+    return ithasOrdersSelected;
+  };
+
+  this.setBulk = function () {
+    self.populateTitles(self.bulkScreen);
+
+    $('> td', self.bulkScreen).attr('colspan', $('th:visible, td:visible', '.widefat:first thead').length);
+    // Insert the editor at the top of the table with an empty row above to maintain zebra striping.
+    $('table.wp-list-table.widefat > tbody').prepend($(self.bulkScreen)).prepend('<tr class="hidden"></tr>');
+    $(self.bulkScreen).show();
+    $('.shipcloud-carrier-select', self.bulkScreen).shipcloudMultiSelect(wcsc_carrier);
+
+    $('button.cancel', self.bulkScreen).click(self.hide);
+
+    $('html, body').animate({scrollTop: 0}, 'fast');
+  };
+
+  this.showPickupForm = function () {
+    self.populateTitles(self.pickupRequestTemplateId);
+    var template = wp.template(self.bulkActionTemplate);
+
+    $('tbody th.check-column input[type="checkbox"]').each(function () {
+      if (!$(this).prop('checked')) {
+        return;
+      }
+
+      var data = {
+        'id': $(this).val(),
+        'title': '#' + $(this).val()
+      };
+
+      $('.order-id-list', self.pickupRequestTemplateId).append(template(data));
+    });
+
+    $('> td', self.pickupRequestTemplateId).attr('colspan', $('th:visible, td:visible', '.widefat:first thead').length);
+    // Insert the editor at the top of the table with an empty row above to maintain zebra striping.
+    $('table.wp-list-table.widefat > tbody').prepend($(self.pickupRequestTemplateId)).prepend('<tr class="hidden"></tr>');
+
+    $('.shipcloud-use-different-pickup-address').click(function () {
+      $('#shipcloud-pickup-request .shipcloud-different-pickup-address').toggle();
+    });
+
+    $('select[name="pickup_address[country]"]').select2();
+    $('.shipcloud__pickup_date_and_time').show();
+    $(self.pickupRequestTemplateId).show();
+  };
+
+  this.hide = function () {
+    $(self.bulkScreen).hide();
+  };
+
+  this.main();
+};
+
+jQuery(function ($) {
+  wcsc.listenBulkActions = new wcsc.OrderBulkActions($('#doaction, #doaction2'));
+});

--- a/includes/js/multi-select.js
+++ b/includes/js/multi-select.js
@@ -39,7 +39,22 @@ shipcloud.MultiSelect = function (wrapperSelector, options) {
         self.renderChildren();
 
         self.$carrier.on('change', self.renderChildren);
+
+        $('.shipcloud__pickup_date_and_time').hide();
+        self.$carrier.on('change', self.renderCarrierSpecificInputs);
     };
+
+  this.renderCarrierSpecificInputs = function () {
+    switch (self.$carrier.val()) {
+      case 'dhl_express':
+      case 'go':
+      case 'tnt':
+        $('.shipcloud__pickup_date_and_time').show();
+        break;
+      default:
+        $('.shipcloud__pickup_date_and_time').hide();
+    }
+  };
 
     this.renderChildren = function () {
         self.renderChild(self.$service, 'services');

--- a/includes/js/shipcloud-label-form.js
+++ b/includes/js/shipcloud-label-form.js
@@ -194,6 +194,17 @@ shipcloud.LabelForm = function (wrapperSelector) {
       return additional_services_array;
     };
 
+  this.handlePickup = function (pointInTime) {
+    var pickupTime =
+      $('input[name="pickup_' + pointInTime + '_date"]').val() +
+      ' ' +
+      $('input[name="pickup_' + pointInTime + '_time_hour"]').val() +
+      ':' +
+      $('input[name="pickup_' + pointInTime + '_time_minute"]').val();
+
+    return pickupTime;
+  };
+
     self.main();
 };
 

--- a/includes/shipcloud/controller/labelcontroller.php
+++ b/includes/shipcloud/controller/labelcontroller.php
@@ -60,6 +60,11 @@ class LabelController {
                 $data['shipment']['carrier']
             );
 
+        $pickup = \WC_Shipcloud_Order::handle_pickup_request($data);
+        if (!empty($pickup)) {
+            $data['shipment']['pickup'] = $pickup;
+        }
+
 		try {
             $order = $this->shipment_repository->findOrderByShipmentId( $data['shipment']['id'] );
 

--- a/includes/shipcloud/repository/shipmentrepository.php
+++ b/includes/shipcloud/repository/shipmentrepository.php
@@ -173,7 +173,7 @@ class ShipmentRepository {
 				'company'    => isset($old_structured_data['recipient_company']) ? $old_structured_data['recipient_company'] : '',
 				'first_name' => isset($old_structured_data['recipient_first_name']) ? $old_structured_data['recipient_first_name'] : '',
 				'last_name'  => isset($old_structured_data['recipient_last_name']) ? $old_structured_data['recipient_last_name'] : '',
-        'care_of'    => isset($old_structured_data['recipient_care_of']) ? $old_structured_data['recipient_care_of'] : '',
+                'care_of'    => isset($old_structured_data['recipient_care_of']) ? $old_structured_data['recipient_care_of'] : '',
 				'street'     => isset($old_structured_data['recipient_street']) ? $old_structured_data['recipient_street'] : '',
 				'street_no'  => isset($old_structured_data['recipient_street_no']) ? $old_structured_data['recipient_street_no'] : '',
 				'zip_code'   => isset($old_structured_data['recipient_zip_code']) ? $old_structured_data['recipient_zip_code'] : '',
@@ -192,7 +192,7 @@ class ShipmentRepository {
 			'tracking_url'        => isset($old_structured_data['tracking_url']) ? $old_structured_data['tracking_url'] : '',
 			'price'               => isset($old_structured_data['price']) ? $old_structured_data['price'] : '',
 			'carrier'             => isset($old_structured_data['carrier']) ? $old_structured_data['carrier'] : '',
-      'service'             => isset($old_structured_data['service']) ? $old_structured_data['service'] : '',
+            'service'             => isset($old_structured_data['service']) ? $old_structured_data['service'] : '',
 			'carrier_tracking_no' => isset($old_structured_data['carrier_tracking_no']) ? $old_structured_data['carrier_tracking_no'] : '',
 			'reference_number'    => isset($old_structured_data['reference_number']) ? $old_structured_data['reference_number'] : '',
 			'additional_services' => isset($old_structured_data['additional_services']) ? $this->handleAdditionalServices( $old_structured_data ) : '',
@@ -203,6 +203,12 @@ class ShipmentRepository {
 				get_post_meta( $order_id, 'shipment_' . $old_structured_data['id'] . '_status', true )
 			);
 		}
+
+        if (isset($old_structured_data['pickup_request'])) {
+            $data['pickup_request'] = $old_structured_data['pickup_request'];
+        } elseif (isset($old_structured_data['pickup'])) {
+            $data['pickup'] = $old_structured_data['pickup'];
+        }
 
 		return $data;
 	}

--- a/includes/shipcloud/shipcloud.php
+++ b/includes/shipcloud/shipcloud.php
@@ -896,6 +896,28 @@ class Woocommerce_Shipcloud_API
 		return new WP_Error( 'shipcloud_api_error_' . $error[ 'name' ], $error[ 'description' ] );
 	}
 
+    /**
+     * Create a pickup request
+     *
+     * @param array $params
+     *
+     * @return array|WP_Error
+     *
+     * @since 1.9.0
+     */
+    public function create_pickup_request( $params ) {
+        $response = $this->send_request( 'pickup_requests', $params, 'POST' );
+
+        $status_code = (int) $response[ 'header' ][ 'status' ];
+
+        if ( 200 !== $status_code ) {
+            $error = $this->get_error( $response );
+            return new WP_Error( $status_code, $error[ 'description' ] );
+        }
+
+        return $response[ 'body' ];
+    }
+
 	public function create_address_by_pakadoo_id( $pakadoo_id ) {
 		$action  = 'addresses';
 		$params = array('pakadoo_id' => $pakadoo_id);
@@ -933,7 +955,6 @@ class Woocommerce_Shipcloud_API
             return new \WP_Error( 'shipcloud_api_error_' . $e->getCode(), $e->getMessage() );
         }
     }
-
 
     public function delete_webhook($webhook_id) {
         $params = array();

--- a/readme.txt
+++ b/readme.txt
@@ -109,11 +109,13 @@ https://youtu.be/HE3jow15x8c
 == Changelog ==
 
 = 1.9.0 =
+* Enhanced: Added possibility to create pickup requests (only in WooCommerce 3)
 * Enhanced: Make it possible to define a global key to be used as reference number. Introduced shortcodes to make the key customizable
 * Enhanced: Added configuration for displaying the pakadoo id within checkout (billing address)
 * Enhanced: Added configuration for displaying a care of field within checkout (billing & shipping address)
 * Enhanced: Added configuration for displaying a phone field within checkout (billing address)
 * Fixed: Use official language for shipments with advance notice
+* Fixed: Link carrier tracking number to carrier tracking page
 
 = 1.8.2 =
 * Enhanced: Show info at api url page if called via get-request

--- a/woocommerce-shipcloud-functions.php
+++ b/woocommerce-shipcloud-functions.php
@@ -559,9 +559,16 @@ function _wcsc_add_order_shipment( $order_id, $shipment, $data, $parcel_title = 
 		'recipient_country'    => $data['to']['country'],
 		'recipient_phone'      => $data['to']['phone'],
 		'reference_number'     => (isset($data['reference_number'])) ? $data['reference_number'] : null,
-		'additional_services'  => $data['additional_services'],
 		'date_created'         => time()
 	);
+
+    if ( array_key_exists( 'additional_services', $data ) && !empty($data['additional_services']) ) {
+        $shipment_data['additional_services'] = $data['additional_services'];
+    }
+
+    if ( array_key_exists( 'pickup', $data ) && !empty($data['pickup']) ) {
+        $shipment_data['pickup'] = $data['pickup'];
+    }
 
 	// Fallback until v2.0.0
 	if ( isset( $data['from']['street_nr'] ) ) {
@@ -678,6 +685,7 @@ function wcsc_get_cod_id() {
 function wcsc_get_carrier_tracking_url( $carrier, $carrier_tracking_no ) {
 	switch ($carrier) {
 		case 'dhl':
+		case 'dhl_express':
 			return 'https://nolp.dhl.de/nextt-online-public/set_identcodes.do?idc='.
 				$carrier_tracking_no.'&rfn=&extendedSearch=true';
 		case 'dpd':


### PR DESCRIPTION
We're adding shipcloud pickup requests, so the carrier will pick up the shipments that the admin created. 

There are two types of pickup options. 
* For express carriers like DHL Express, UPS and TNT you nee to supply a "_pickup object_" when creating a shipment (see [Shipments with Pickup Requests](https://developers.shipcloud.io/concepts/#misc-carrier-specifics)).
* For most of the other carriers (except DHL, because they don't supply a service for creating pickup requests) you need to send a [separate pickup request](https://developers.shipcloud.io/reference/#pickup-requests) once a day where you aggregate the shipments that should be picked up.

This PR not only includes the functionality to create pickup requests from a single order or via batch processing. It also changes the way the action buttons are displayed based on the context of each shipment. Also the shipment form got a tiny redesign to make it more straight forward.