### PR TITLE
added new services DHL Europaket and UPS Expedited

### DIFF
--- a/components/core/parcel-template.php
+++ b/components/core/parcel-template.php
@@ -335,7 +335,7 @@ class WCSC_Parceltemplate_Posttype
 
 
 		$post_title = wcsc_get_carrier_display_name( $request['shipcloud_carrier'] )
-					  . ' ' . wcsc_api()->get_service_label( $request['shipcloud_carrier_service'] )
+					  . ' ' . wcsc_api()->get_service_name( $request['shipcloud_carrier_service'] )
 					  . ' (' . WC_Shipcloud_Order::instance()->get_package_label( $request['shipcloud_carrier_package'] ) . ')'
 					  . ' - ' . $width
 					  . ' x ' . $height

--- a/includes/shipcloud/shipcloud.php
+++ b/includes/shipcloud/shipcloud.php
@@ -106,6 +106,16 @@ class Woocommerce_Shipcloud_API
 				'description'      => __( 'Small trackable letter delivery', 'shipcloud-for-woocommerce' ),
 				'customer_service' => false
 			),
+            'dhl_europaket' => array(
+                'name' => __( 'Europaket', 'shipcloud-for-woocommerce' ),
+                'description' => __( 'B2B parcel shipments delivered mostly within 48 hours', 'shipcloud-for-woocommerce' ),
+                'customer_service' => false
+            ),
+            'ups_expedited' => array(
+                'name' => __( 'Expedited', 'shipcloud-for-woocommerce' ),
+                'description' => __( 'For sending less urgent shipments to destinations outside of Europe', 'shipcloud-for-woocommerce' ),
+                'customer_service' => false
+            ),
 		);
 	}
 
@@ -120,23 +130,6 @@ class Woocommerce_Shipcloud_API
 	 */
 	public function get_services() {
 		return $this->services;
-	}
-
-	/**
-	 * Turn service into label.
-	 *
-	 * @param $service_name
-	 *
-	 * @return string Label of the service (the name if non was found).
-	 */
-	public function get_service_label( $service_name ) {
-		if ( ! isset( $this->services[ $service_name ] )
-			 || ! isset( $this->services[ $service_name ]['name'] )
-		) {
-			return $service_name;
-		}
-
-		return $this->services[ $service_name ]['name'];
 	}
 
 	/**
@@ -506,12 +499,12 @@ class Woocommerce_Shipcloud_API
 	 * @return string
 	 * @since 1.0.0
 	 */
-	public function get_service_name( $service_id ) {
-		if ( ! array_key_exists( $service_id, $this->services ) ) {
-			return false;
+	public function get_service_name( $service_name ) {
+		if (array_key_exists($service_name, $this->services)) {
+			return $this->services[ $service_name ]['name'];
+		} else {
+			return $service_name;
 		}
-
-		return $this->services[ $service_id ]['name'];
 	}
 
 	/**

--- a/woocommerce-shipcloud.php
+++ b/woocommerce-shipcloud.php
@@ -395,7 +395,20 @@ class WooCommerce_Shipcloud {
 		);
 
 		// Inject translations and data for carrier selection.
-		wp_localize_script(
+		$services = array(
+            'placeholder' => _x( 'Select service', 'backend: Selecting a carrier service option for label creation', 'wcsc' )
+        );
+        $services = array_merge(
+            $services,
+            array_map(
+                function($service) {
+                    return $service['name'];
+                },
+                wcsc_api()->get_services()
+            )
+        );
+
+        wp_localize_script(
 			'wcsc-multi-select',
 			'wcsc_carrier',
 			array(
@@ -411,16 +424,7 @@ class WooCommerce_Shipcloud {
 						'parcel' => _x( 'Parcel', 'pacakge type: parcel', 'wcsc' ),
 						'bulk' => _x( 'Bulk', 'pacakge type: bulk', 'wcsc' ),
 					),
-					'services' => array(
-						'placeholder' => _x( 'Select service', 'backend: Selecting a carrier service option for label creation', 'wcsc' ),
-						'standard' => wcsc_api()->get_service_label('standard'),
-						'one_day' => wcsc_api()->get_service_label('one_day'),
-						'one_day_early' => wcsc_api()->get_service_label('one_day_early'),
-						'same_day' => wcsc_api()->get_service_label('same_day'),
-						'returns' => wcsc_api()->get_service_label('returns'),
-                        'ups_express_1200' => wcsc_api()->get_service_label('ups_express_1200'),
-                        'dpag_warenpost' => wcsc_api()->get_service_label('dpag_warenpost'),
-					),
+					'services' => $services
 				),
 				'data'    => _wcsc_carriers_get(),
 			)


### PR DESCRIPTION
- `get_service_name` will now return a string (as documented)
  When trying to get a services name we'll now check if it is present in services array. If not we'll return the service_name itself to show the services key at least. This makes introducing new services easier, since there will always be a name displayed.
- replace `get_service_label` with `get_service_name`
  since they were doing the same thing


