### PR TITLE
add package types for Cargo international

### DIFF
--- a/components/core/parcel-template.php
+++ b/components/core/parcel-template.php
@@ -271,13 +271,7 @@ class WCSC_Parceltemplate_Posttype
      * @deprecated 2.0.0 This is duplicate to \WC_Shipcloud_Order::get_package_label and needs to be injected.
 	 */
 	protected static function get_package_label( $slug ) {
-		$labels = array(
-			'books'         => _x( 'Books', 'label while creating shipping label', 'shipcloud-woocommerce' ),
-			'bulk'          => _x( 'Bulk', 'label for oversize packages', 'shipcloud-woocommerce' ),
-			'letter'        => _x( 'Letter', 'label for simple letters', 'shipcloud-woocommerce' ),
-			'parcel'        => _x( 'Parcel', 'label for simple packages', 'shipcloud-woocommerce' ),
-			'parcel_letter' => _x( 'Parcel letter', 'letter for goods', 'shipcloud-woocommerce' ),
-		);
+		$labels = wcsc_api()->get_package_types();
 
 		if ( ! isset( $labels[ $slug ] ) ) {
 			return $slug;

--- a/components/woo/order.php
+++ b/components/woo/order.php
@@ -1860,7 +1860,8 @@ class WC_Shipcloud_Order
 					   . $data->height . esc_attr( 'x', 'shipcloud-for-woocommerce' )
 					   . $data->length . esc_attr( 'cm', 'shipcloud-for-woocommerce' )
 					   . ' - ' . $data->weight . esc_attr( 'kg', 'shipcloud-for-woocommerce' )
-					   . ' - ' . $this->get_shipcloud_api()->get_carrier_display_name_short( $data->carrier );
+					   . ' - ' . wcsc_get_carrier_display_name($carrier['carrier'])
+                       . ' - ' . $this->get_shipcloud_api()->get_service_name( $carrier['service'] );
 
 			if ( $carrier['package'] ) {
 				$option .= ' - ' . WC_Shipcloud_Order::instance()->get_package_label( $carrier['package'] );
@@ -1914,13 +1915,7 @@ class WC_Shipcloud_Order
      * @deprecated 2.0.0 This is duplicate to \WCSC_Parceltemplate_Posttype::get_package_label and needs to be injected.
 	 */
 	public function get_package_label( $slug ) {
-		$labels = array(
-			'books'         => _x( 'Books', 'label while creating shipping label', 'shipcloud-woocommerce' ),
-			'bulk'          => _x( 'Bulk', 'label for oversize packages', 'shipcloud-woocommerce' ),
-			'letter'        => _x( 'Letter', 'label for simple letters', 'shipcloud-woocommerce' ),
-			'parcel'        => _x( 'Parcel', 'label for simple packages', 'shipcloud-woocommerce' ),
-			'parcel_letter' => _x( 'Parcel letter', 'letter for goods', 'shipcloud-woocommerce' ),
-		);
+		$labels = wcsc_api()->get_package_types();
 
 		if ( ! isset( $labels[ $slug ] ) ) {
 			return $slug;

--- a/includes/js/multi-select.js
+++ b/includes/js/multi-select.js
@@ -96,6 +96,8 @@ shipcloud.MultiSelect = function (wrapperSelector, options) {
             self.$carrier.val(map['carrier']);
         }
 
+        self.renderChildren();
+
         if (map.hasOwnProperty('service') && map['service']) {
             self.$service.val(map['service']);
         }

--- a/includes/shipcloud/shipcloud.php
+++ b/includes/shipcloud/shipcloud.php
@@ -116,7 +116,21 @@ class Woocommerce_Shipcloud_API
                 'description' => __( 'For sending less urgent shipments to destinations outside of Europe', 'shipcloud-for-woocommerce' ),
                 'customer_service' => false
             ),
+            'cargo_international_express' => array(
+              'name' => __( 'Express', 'shipcloud-for-woocommerce' ),
+              'description' => __( 'Express delivery for Cargo International shipments', 'shipcloud-for-woocommerce' ),
+              'customer_service' => false
+            ),
 		);
+        $this->package_types = array(
+            'letter' => _x( 'Letter', 'package type: letter', 'shipcloud-for-woocommerce' ),
+            'parcel_letter' => _x( 'Parcel letter', 'package type: parcel letter', 'shipcloud-for-woocommerce' ),
+            'books' => _x( 'Books', 'package type: books', 'shipcloud-for-woocommerce' ),
+            'parcel' => _x( 'Parcel', 'package type: parcel', 'shipcloud-for-woocommerce' ),
+            'bulk' => _x( 'Bulk', 'package type: bulk', 'shipcloud-for-woocommerce' ),
+            'disposable_pallet' => _x( 'Disposable pallet', 'package type: disposable pallet', 'shipcloud-for-woocommerce' ),
+            'euro_pallet' => _x( 'Euro pallet', 'package type: euro pallet', 'shipcloud-for-woocommerce' ),
+        );
 	}
 
 	public function is_valid() {
@@ -124,6 +138,15 @@ class Woocommerce_Shipcloud_API
 	}
 
 	/**
+	 * Retrieve all package types.
+	 *
+	 * @return array
+	 */
+	public function get_package_types() {
+		return $this->package_types;
+	}
+
+    /**
 	 * Retrieve all services.
 	 *
 	 * @return array

--- a/woocommerce-shipcloud.php
+++ b/woocommerce-shipcloud.php
@@ -394,6 +394,14 @@ class WooCommerce_Shipcloud {
 			static::VERSION
 		);
 
+        $package_types = array(
+            'placeholder' => _x( 'Select type', 'backend: Selecting a package type option for label creation', 'wcsc' ),
+        );
+        $package_types = array_merge(
+            $package_types,
+            wcsc_api()->get_package_types()
+        );
+
 		// Inject translations and data for carrier selection.
 		$services = array(
             'placeholder' => _x( 'Select service', 'backend: Selecting a carrier service option for label creation', 'wcsc' )
@@ -416,14 +424,7 @@ class WooCommerce_Shipcloud {
 					'carrier' => array(
 						'placeholder' => _x( 'Select carrier', 'backend: Selecting a carrier option for label creation', 'wcsc' ),
 					),
-					'package_types' => array(
-						'placeholder' => _x( 'Select type', 'backend: Selecting a package type option for label creation', 'wcsc' ),
-						'letter' => _x( 'Letter', 'package type: letter', 'wcsc' ),
-						'parcel_letter' => _x( 'Parcel letter', 'package type: parcel letter', 'wcsc' ),
-						'books' => _x( 'Books', 'package type: books', 'wcsc' ),
-						'parcel' => _x( 'Parcel', 'pacakge type: parcel', 'wcsc' ),
-						'bulk' => _x( 'Bulk', 'pacakge type: bulk', 'wcsc' ),
-					),
+					'package_types' => $package_types,
 					'services' => $services
 				),
 				'data'    => _wcsc_carriers_get(),


### PR DESCRIPTION
Also rewrote the way to get the package types. You can now get them via
`wcsc_api()->get_package_types()` directly.

